### PR TITLE
Add GitHub + Mermaid wardley-beta support

### DIFF
--- a/docs/superpowers/plans/2026-05-20-github-mermaid-wardley-beta.md
+++ b/docs/superpowers/plans/2026-05-20-github-mermaid-wardley-beta.md
@@ -1,0 +1,1599 @@
+# GitHub + Mermaid wardley-beta Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user open a Wardley map stored as a Mermaid `wardley-beta` code fence in a GitHub repo, edit it in OnlineWardleyMaps, and commit it back to the same file.
+
+**Architecture:** A bidirectional OWM↔Mermaid converter (the export side is a TypeScript port of the validated `tractorjuice/wardley-maps-mermaid` `convert.mjs`), plus a PAT-authenticated GitHub `LoadStrategy`/`SaveStrategy` pair that plugs into the existing `LoadMap`/`SaveMap` dispatchers. An "Open from GitHub" dialog drives it.
+
+**Tech Stack:** Next.js 16, React, TypeScript, MUI, Jest (jsdom), GitHub REST API.
+
+**Working directory:** All paths are relative to `/workspaces/onlinewardleymaps-rebrand`. Branch: `feat/github-mermaid-wardley`. Run all commands from `frontend/` unless stated otherwise. Design spec: `docs/superpowers/specs/2026-05-20-github-mermaid-wardley-beta-design.md`.
+
+---
+
+## File Structure
+
+**Created — Mermaid converter (`frontend/src/conversion/mermaid/`):**
+- `owmOnlyKeywords.ts` — `isOwmOnlyLine()`: detects OWM keywords Mermaid `wardley-beta` cannot render. Shared by exporter and importer.
+- `MermaidExporter.ts` — `exportToMermaid()`: OWM `mapText` → Mermaid string. Ported from `convert.mjs`.
+- `MermaidImporter.ts` — `importFromMermaid()`: Mermaid string → OWM `mapText`.
+
+**Created — GitHub access (`frontend/src/repository/github/`):**
+- `GitHubUrl.ts` — `parseGitHubUrl()`: GitHub blob URL → `{owner,repo,branch,path}`.
+- `MermaidFence.ts` — `extractMermaidFence()` / `replaceMermaidFence()`: read/write the fence inside a Markdown file.
+- `GitHubToken.ts` — PAT `localStorage` read/write/clear.
+- `GitHubMapSession.ts` — in-memory holder for the open map's source + blob `sha` + raw file content.
+- `GitHubClient.ts` — `readFile()` / `commitFile()` over the GitHub REST API.
+
+**Created — persistence strategies (`frontend/src/repository/`):**
+- `GitHubLoadStrategy.ts`, `GitHubSaveStrategy.ts`.
+
+**Created — UI (`frontend/src/components/github/`):**
+- `OpenFromGitHubDialog.tsx` — the open dialog.
+
+**Modified:**
+- `frontend/src/constants/defaults.ts` — add `MapPersistenceStrategy.GitHub`.
+- `frontend/src/repository/LoadMap.ts`, `frontend/src/repository/SaveMap.ts` — register strategies.
+- `frontend/wmlandscape/src/index.js` — re-export the converter.
+- `frontend/src/components/MapEnvironment.tsx`, `frontend/src/components/map/components/MapLayout.tsx`, `frontend/src/components/page/NewHeader.tsx` — wire the dialog.
+
+**Tests:** `frontend/src/__tests__/conversion/mermaid/` and `frontend/src/__tests__/repository/github/`, plus `OpenFromGitHubDialog.test.tsx` alongside the component.
+
+---
+
+## Task 1: `isOwmOnlyLine()` keyword detector
+
+**Files:**
+- Create: `frontend/src/conversion/mermaid/owmOnlyKeywords.ts`
+- Test: `frontend/src/__tests__/conversion/mermaid/owmOnlyKeywords.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import {isOwmOnlyLine} from '../../../conversion/mermaid/owmOnlyKeywords';
+
+describe('isOwmOnlyLine', () => {
+	it.each([
+		'style wardley',
+		'build Foo',
+		'x-axis Genesis -> Commodity',
+		'y-axis Value -> Invisible',
+		'market Customers [0.9, 0.5]',
+		'ecosystem Things [0.5, 0.5]',
+		'submap Foo [0.5, 0.5]',
+		'url foo https://example.com',
+		'pioneers [0.1, 0.1, 0.2, 0.2]',
+		'accelerator Speed [0.5, 0.5]',
+	])('treats "%s" as an OWM-only line', line => {
+		expect(isOwmOnlyLine(line)).toBe(true);
+	});
+
+	it.each([
+		'component Foo [0.5, 0.5]',
+		'anchor User [0.9, 0.9]',
+		'Market segmentation -> Last Mile',
+		'evolve Kettle 0.62',
+		'',
+	])('treats "%s" as a normal line', line => {
+		expect(isOwmOnlyLine(line)).toBe(false);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && yarn test src/__tests__/conversion/mermaid/owmOnlyKeywords.test.ts`
+Expected: FAIL — cannot find module `owmOnlyKeywords`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// OWM keywords that have no Mermaid wardley-beta equivalent. Lines matching
+// these are preserved as `%%` comments on export and restored on import.
+const OWM_ONLY_PATTERNS: RegExp[] = [
+	/^style\s+wardley\s*$/i,
+	/^(build|buy|outsource)\s+/i,
+	/^[xy]-axis\s+/i,
+	// `market <name> [vis, evo]` only — must not match links like
+	// `Market segmentation -> Last Mile`.
+	/^market\s+[^[\]]+\[\s*[\d.]+\s*,/i,
+	/^(ecosystem|submap|url)\s+/i,
+	/^(pioneers?|settlers?|townplanners?)\b/i,
+	/^(accelerator|deaccelerator)\s+/i,
+];
+
+export const isOwmOnlyLine = (line: string): boolean => {
+	const trimmed = line.trim();
+	return OWM_ONLY_PATTERNS.some(re => re.test(trimmed));
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && yarn test src/__tests__/conversion/mermaid/owmOnlyKeywords.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+git add frontend/src/conversion/mermaid/owmOnlyKeywords.ts frontend/src/__tests__/conversion/mermaid/owmOnlyKeywords.test.ts
+git commit -m "feat: add isOwmOnlyLine keyword detector for Mermaid conversion"
+```
+
+---
+
+## Task 2: Port `convert.mjs` to `MermaidExporter.ts`
+
+This task vendors the validated converter and makes it compile as TypeScript. Behaviour is unchanged here — the comment-emit modification is Task 3.
+
+**Files:**
+- Create: `frontend/src/conversion/mermaid/MermaidExporter.ts`
+- Test: `frontend/src/__tests__/conversion/mermaid/MermaidExporter.test.ts`
+
+- [ ] **Step 1: Write the failing smoke test**
+
+```ts
+import {exportToMermaid} from '../../../conversion/mermaid/MermaidExporter';
+
+describe('exportToMermaid', () => {
+	it('emits a wardley-beta header', () => {
+		const result = exportToMermaid('title Test\ncomponent Foo [0.5, 0.5]');
+		expect(result.mermaid.split('\n')[0]).toBe('wardley-beta');
+	});
+
+	it('passes a component through unchanged', () => {
+		const result = exportToMermaid('component Foo [0.5, 0.5]');
+		expect(result.mermaid).toContain('component Foo [0.5, 0.5]');
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && yarn test src/__tests__/conversion/mermaid/MermaidExporter.test.ts`
+Expected: FAIL — cannot find module `MermaidExporter`.
+
+- [ ] **Step 3: Download the source converter**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+curl -sL https://raw.githubusercontent.com/tractorjuice/wardley-maps-mermaid/main/tools/convert.mjs \
+  -o frontend/src/conversion/mermaid/MermaidExporter.ts
+```
+
+- [ ] **Step 4: Remove Node-only code**
+
+Edit `frontend/src/conversion/mermaid/MermaidExporter.ts`:
+
+1. Delete the two import lines near the top:
+   ```ts
+   import { readFileSync, readdirSync } from 'node:fs';
+   import { join, basename } from 'node:path';
+   ```
+2. Delete the entire `export function findMapFiles(dir) { ... }` function (it uses `readdirSync`/`join` and is not needed in the browser).
+3. Add this as the new first line of the file:
+   ```ts
+   /* eslint-disable @typescript-eslint/no-explicit-any */
+   ```
+
+- [ ] **Step 5: Add TypeScript annotations**
+
+In the same file, annotate every function parameter (TypeScript strict mode rejects implicit `any`):
+
+- `function normaliseLabel(labelStr)` → `function normaliseLabel(labelStr: string)`
+- `function startsWithReserved(name)` → `function startsWithReserved(name: string)`
+- `export function quoteName(name)` → `export function quoteName(name: string)`
+- `export function owmToMermaid(owmContent, filename)` → `export function exportToMermaid(owmContent: string, titleFallback?: string): {mermaid: string; keptAsComments: string[]}`
+  (rename the function and add the return type now; the body still returns a string — fixed in the next step).
+
+Inside `exportToMermaid`, find the three metadata objects and type them as `Record<string, any>`:
+```ts
+const sourcing: Record<string, any> = {};
+const compCoords: Record<string, any> = {};
+const pipelineRanges: Record<string, any> = {};
+```
+(`pipelinesWithExplicitBlock` is a `new Set()` — leave it; add `<string>` if the compiler complains: `new Set<string>()`.)
+
+- [ ] **Step 6: Replace the `basename`-based default title**
+
+Find the block near the end of the function:
+```ts
+  if (!hasTitleLine) {
+    const defaultTitle = basename(filename).replace(/\.\w+$/, '').replace(/[-_]/g, ' ');
+    mermaidLines.splice(1, 0, `title ${defaultTitle}`, 'size [1100, 800]');
+  }
+```
+Replace it with:
+```ts
+  if (!hasTitleLine) {
+    const defaultTitle = (titleFallback || 'Wardley Map').replace(/[-_]/g, ' ');
+    mermaidLines.splice(1, 0, `title ${defaultTitle}`, 'size [1100, 800]');
+  }
+```
+
+- [ ] **Step 7: Make the function return a string for now**
+
+The final line of `exportToMermaid` currently is `return cleaned.join('\n');`. Temporarily change it to satisfy the declared return type:
+```ts
+  return {mermaid: cleaned.join('\n'), keptAsComments: []};
+```
+Add `const keptAsComments: string[] = [];` immediately after `const mermaidLines = ['wardley-beta'];` near the top of the function (it stays empty until Task 3).
+
+- [ ] **Step 8: Type-check and run the test**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no errors in `MermaidExporter.ts`. Fix any remaining `implicit any` by adding a type annotation (use `any` if the value is genuinely dynamic).
+
+Run: `cd frontend && yarn test src/__tests__/conversion/mermaid/MermaidExporter.test.ts`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+git add frontend/src/conversion/mermaid/MermaidExporter.ts frontend/src/__tests__/conversion/mermaid/MermaidExporter.test.ts
+git commit -m "feat: port OWM-to-Mermaid converter to TypeScript"
+```
+
+---
+
+## Task 3: Emit unsupported keywords as comments
+
+Modifies `exportToMermaid` so OWM-only lines become `%%` Mermaid comments instead of being dropped, and are reported in `keptAsComments`.
+
+**Files:**
+- Modify: `frontend/src/conversion/mermaid/MermaidExporter.ts`
+- Test: `frontend/src/__tests__/conversion/mermaid/MermaidExporter.test.ts`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `MermaidExporter.test.ts`:
+
+```ts
+describe('exportToMermaid — unsupported keywords', () => {
+	it('preserves a market line as a %% comment', () => {
+		const result = exportToMermaid('component Foo [0.5, 0.5]\nmarket Buyers [0.9, 0.5]');
+		expect(result.mermaid).toContain('%% market Buyers [0.9, 0.5]');
+		expect(result.keptAsComments).toContain('market Buyers [0.9, 0.5]');
+	});
+
+	it('does not list normal lines in keptAsComments', () => {
+		const result = exportToMermaid('component Foo [0.5, 0.5]');
+		expect(result.keptAsComments).toEqual([]);
+	});
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && yarn test src/__tests__/conversion/mermaid/MermaidExporter.test.ts`
+Expected: FAIL — `market` line is dropped, not commented.
+
+- [ ] **Step 3: Apply the modification**
+
+In `MermaidExporter.ts`:
+
+1. Add an import at the top (after the eslint-disable line):
+   ```ts
+   import {isOwmOnlyLine} from './owmOnlyKeywords';
+   ```
+2. In `exportToMermaid`, find these five consecutive lines in the main emit loop:
+   ```ts
+   if (/^style\s+wardley\s*$/i.test(trimmed)) continue;
+   if (/^(build|buy|outsource)\s+/i.test(trimmed)) continue;
+   if (/^[xy]-axis\s+/i.test(trimmed)) continue;
+   if (/^market\s+[^[\]]+\[\s*[\d.]+\s*,/i.test(trimmed)) continue;
+   if (/^(ecosystem|submap|url|pioneer|settler|townplanner)\s+/i.test(trimmed)) continue;
+   ```
+   Replace all five with:
+   ```ts
+   if (isOwmOnlyLine(trimmed)) {
+   	mermaidLines.push(`%% ${trimmed}`);
+   	keptAsComments.push(trimmed);
+   	continue;
+   }
+   ```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && yarn test src/__tests__/conversion/mermaid/MermaidExporter.test.ts`
+Expected: PASS (all tests in the file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+git add frontend/src/conversion/mermaid/MermaidExporter.ts frontend/src/__tests__/conversion/mermaid/MermaidExporter.test.ts
+git commit -m "feat: preserve unsupported OWM keywords as Mermaid comments"
+```
+
+---
+
+## Task 4: `importFromMermaid()`
+
+**Files:**
+- Create: `frontend/src/conversion/mermaid/MermaidImporter.ts`
+- Test: `frontend/src/__tests__/conversion/mermaid/MermaidImporter.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import {importFromMermaid} from '../../../conversion/mermaid/MermaidImporter';
+
+describe('importFromMermaid', () => {
+	it('strips the wardley-beta header line', () => {
+		const owm = importFromMermaid('wardley-beta\ncomponent Foo [0.5, 0.5]');
+		expect(owm).not.toContain('wardley-beta');
+		expect(owm).toContain('component Foo [0.5, 0.5]');
+	});
+
+	it('strips the auto-injected size line', () => {
+		const owm = importFromMermaid('wardley-beta\ntitle T\nsize [1100, 800]\ncomponent Foo [0.5, 0.5]');
+		expect(owm).not.toContain('size [1100, 800]');
+	});
+
+	it('restores OWM-only keywords from %% comments', () => {
+		const owm = importFromMermaid('wardley-beta\n%% market Buyers [0.9, 0.5]\ncomponent Foo [0.5, 0.5]');
+		expect(owm).toContain('market Buyers [0.9, 0.5]');
+	});
+
+	it('drops %% comments that are not OWM keywords', () => {
+		const owm = importFromMermaid('wardley-beta\n%% just a note\ncomponent Foo [0.5, 0.5]');
+		expect(owm).not.toContain('just a note');
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && yarn test src/__tests__/conversion/mermaid/MermaidImporter.test.ts`
+Expected: FAIL — cannot find module `MermaidImporter`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+import {isOwmOnlyLine} from './owmOnlyKeywords';
+
+// Converts a Mermaid wardley-beta diagram body into OWM DSL. The body is
+// already valid OWM apart from the `wardley-beta` header and the
+// auto-injected `size` line; `%%` comments holding OWM-only keywords
+// (written by exportToMermaid) are un-commented.
+export const importFromMermaid = (mermaidText: string): string => {
+	const out: string[] = [];
+	for (const line of mermaidText.split('\n')) {
+		const trimmed = line.trim();
+
+		if (/^wardley-beta\s*$/i.test(trimmed)) continue;
+		if (/^size\s*\[/i.test(trimmed)) continue;
+
+		const commentMatch = trimmed.match(/^%%\s?(.*)$/);
+		if (commentMatch) {
+			const body = commentMatch[1];
+			if (isOwmOnlyLine(body.trim())) out.push(body);
+			continue;
+		}
+
+		out.push(line);
+	}
+	return out.join('\n');
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && yarn test src/__tests__/conversion/mermaid/MermaidImporter.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+git add frontend/src/conversion/mermaid/MermaidImporter.ts frontend/src/__tests__/conversion/mermaid/MermaidImporter.test.ts
+git commit -m "feat: add importFromMermaid converter"
+```
+
+---
+
+## Task 5: Round-trip test suite
+
+Verifies OWM → Mermaid → OWM preserves the map, including OWM-only keywords. Comparison is normalised because the exporter strips comments, collapses blank lines, and adds a `size` line.
+
+**Files:**
+- Test: `frontend/src/__tests__/conversion/mermaid/roundTrip.test.ts`
+
+- [ ] **Step 1: Write the round-trip test**
+
+```ts
+import {exportToMermaid} from '../../../conversion/mermaid/MermaidExporter';
+import {importFromMermaid} from '../../../conversion/mermaid/MermaidImporter';
+
+// Normalise for comparison: drop blank lines and trim each line. The
+// exporter intentionally collapses blanks and strips `//` comments.
+const normalise = (text: string): string[] =>
+	text
+		.split('\n')
+		.map(l => l.trim())
+		.filter(l => l.length > 0 && !l.startsWith('//'));
+
+const SAMPLE = [
+	'title Tea Shop',
+	'anchor Business [0.95, 0.63]',
+	'component Cup of Tea [0.79, 0.61]',
+	'component Kettle [0.43, 0.35]',
+	'Business -> Cup of Tea',
+	'Cup of Tea -> Kettle',
+	'evolve Kettle 0.62',
+	'market Buyers [0.9, 0.5]',
+].join('\n');
+
+describe('OWM <-> Mermaid round trip', () => {
+	it('preserves every meaningful line', () => {
+		const mermaid = exportToMermaid(SAMPLE).mermaid;
+		const backToOwm = importFromMermaid(mermaid);
+		const original = normalise(SAMPLE);
+		const result = normalise(backToOwm);
+		for (const line of original) {
+			expect(result).toContain(line);
+		}
+	});
+
+	it('round-trips the OWM-only market keyword', () => {
+		const mermaid = exportToMermaid(SAMPLE).mermaid;
+		expect(mermaid).toContain('%% market Buyers [0.9, 0.5]');
+		expect(normalise(importFromMermaid(mermaid))).toContain('market Buyers [0.9, 0.5]');
+	});
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd frontend && yarn test src/__tests__/conversion/mermaid/roundTrip.test.ts`
+Expected: PASS. If a line fails to round-trip, inspect the exporter output for that line — the exporter may reformat it (e.g. `evolve` spacing); update the `SAMPLE`/`normalise` expectations only if the reformatting is semantically equivalent, otherwise fix the converter.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+git add frontend/src/__tests__/conversion/mermaid/roundTrip.test.ts
+git commit -m "test: add OWM-Mermaid round-trip suite"
+```
+
+---
+
+## Task 6: Re-export the converter from `wmlandscape`
+
+**Files:**
+- Modify: `frontend/wmlandscape/src/index.js`
+
+- [ ] **Step 1: Add the imports**
+
+In `frontend/wmlandscape/src/index.js`, alongside the other `../../src/conversion/...` imports (near line 60-82), add:
+
+```js
+import {exportToMermaid} from '../../src/conversion/mermaid/MermaidExporter';
+import {importFromMermaid} from '../../src/conversion/mermaid/MermaidImporter';
+```
+
+- [ ] **Step 2: Add to the export block**
+
+In the `export { ... }` block (near line 97), add `exportToMermaid,` and `importFromMermaid,` as new entries.
+
+- [ ] **Step 3: Verify the package builds**
+
+Run: `cd frontend && yarn package`
+Expected: Rollup build succeeds with no errors referencing the new modules.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+git add frontend/wmlandscape/src/index.js
+git commit -m "feat: export Mermaid converter from wmlandscape package"
+```
+
+---
+
+## Task 7: `parseGitHubUrl()`
+
+**Files:**
+- Create: `frontend/src/repository/github/GitHubUrl.ts`
+- Test: `frontend/src/__tests__/repository/github/GitHubUrl.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import {parseGitHubUrl} from '../../../repository/github/GitHubUrl';
+
+describe('parseGitHubUrl', () => {
+	it('parses a blob URL', () => {
+		const r = parseGitHubUrl('https://github.com/acme/maps/blob/main/docs/tea.md');
+		expect(r).toEqual({owner: 'acme', repo: 'maps', branch: 'main', path: 'docs/tea.md'});
+	});
+
+	it('parses a path with nested folders', () => {
+		const r = parseGitHubUrl('https://github.com/a/b/blob/dev/x/y/z.md');
+		expect(r).toEqual({owner: 'a', repo: 'b', branch: 'dev', path: 'x/y/z.md'});
+	});
+
+	it('returns null for a non-blob GitHub URL', () => {
+		expect(parseGitHubUrl('https://github.com/acme/maps')).toBeNull();
+	});
+
+	it('returns null for a non-GitHub URL', () => {
+		expect(parseGitHubUrl('https://example.com/foo')).toBeNull();
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && yarn test src/__tests__/repository/github/GitHubUrl.test.ts`
+Expected: FAIL — cannot find module `GitHubUrl`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+export interface GitHubSource {
+	owner: string;
+	repo: string;
+	branch: string;
+	path: string;
+}
+
+// Parses https://github.com/{owner}/{repo}/blob/{branch}/{path...}
+export const parseGitHubUrl = (url: string): GitHubSource | null => {
+	const match = url
+		.trim()
+		.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/([^/]+)\/(.+)$/);
+	if (!match) return null;
+	const [, owner, repo, branch, path] = match;
+	return {owner, repo, branch, path};
+};
+
+// id form used by the persistence layer: owner/repo/branch/path...
+export const sourceToId = (s: GitHubSource): string =>
+	`${s.owner}/${s.repo}/${s.branch}/${s.path}`;
+
+export const idToSource = (id: string): GitHubSource => {
+	const [owner, repo, branch, ...rest] = id.split('/');
+	return {owner, repo, branch, path: rest.join('/')};
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && yarn test src/__tests__/repository/github/GitHubUrl.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+git add frontend/src/repository/github/GitHubUrl.ts frontend/src/__tests__/repository/github/GitHubUrl.test.ts
+git commit -m "feat: add GitHub URL parser"
+```
+
+---
+
+## Task 8: `MermaidFence` extract/replace
+
+**Files:**
+- Create: `frontend/src/repository/github/MermaidFence.ts`
+- Test: `frontend/src/__tests__/repository/github/MermaidFence.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import {extractMermaidFence, replaceMermaidFence} from '../../../repository/github/MermaidFence';
+
+const MD = [
+	'# My Map',
+	'Some prose.',
+	'```mermaid',
+	'wardley-beta',
+	'component Foo [0.5, 0.5]',
+	'```',
+	'More prose.',
+].join('\n');
+
+describe('extractMermaidFence', () => {
+	it('extracts the wardley-beta fence body', () => {
+		const r = extractMermaidFence(MD);
+		expect(r.hasFence).toBe(true);
+		expect(r.body).toBe('wardley-beta\ncomponent Foo [0.5, 0.5]');
+	});
+
+	it('treats a file with no fence as the whole body', () => {
+		const r = extractMermaidFence('wardley-beta\ncomponent Foo [0.5, 0.5]');
+		expect(r.hasFence).toBe(false);
+		expect(r.body).toBe('wardley-beta\ncomponent Foo [0.5, 0.5]');
+	});
+});
+
+describe('replaceMermaidFence', () => {
+	it('replaces the fence body and keeps surrounding prose', () => {
+		const out = replaceMermaidFence(MD, 'wardley-beta\ncomponent Bar [0.1, 0.2]');
+		expect(out).toContain('# My Map');
+		expect(out).toContain('More prose.');
+		expect(out).toContain('component Bar [0.1, 0.2]');
+		expect(out).not.toContain('component Foo');
+	});
+
+	it('returns the new body alone when there was no fence', () => {
+		const out = replaceMermaidFence('wardley-beta\ncomponent Foo [0.5, 0.5]', 'wardley-beta\nx');
+		expect(out).toBe('wardley-beta\nx');
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && yarn test src/__tests__/repository/github/MermaidFence.test.ts`
+Expected: FAIL — cannot find module `MermaidFence`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+export interface FenceResult {
+	body: string;
+	hasFence: boolean;
+}
+
+// Matches a ```mermaid ... ``` fenced block. Group 1 = opening fence line
+// (with any info string), group 2 = body, group 3 = closing fence.
+const FENCE_RE = /(```mermaid[^\n]*\n)([\s\S]*?)(\n```)/g;
+
+const findWardleyFence = (fileContent: string): RegExpExecArray | null => {
+	FENCE_RE.lastIndex = 0;
+	let match: RegExpExecArray | null;
+	while ((match = FENCE_RE.exec(fileContent)) !== null) {
+		if (/^\s*wardley-beta\b/.test(match[2])) return match;
+	}
+	return null;
+};
+
+export const extractMermaidFence = (fileContent: string): FenceResult => {
+	const match = findWardleyFence(fileContent);
+	if (!match) return {body: fileContent, hasFence: false};
+	return {body: match[2].trim(), hasFence: true};
+};
+
+export const replaceMermaidFence = (fileContent: string, newBody: string): string => {
+	const match = findWardleyFence(fileContent);
+	if (!match) return newBody;
+	const replacement = `${match[1]}${newBody}${match[3]}`;
+	return fileContent.slice(0, match.index) + replacement + fileContent.slice(match.index + match[0].length);
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && yarn test src/__tests__/repository/github/MermaidFence.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+git add frontend/src/repository/github/MermaidFence.ts frontend/src/__tests__/repository/github/MermaidFence.test.ts
+git commit -m "feat: add Mermaid fence extract/replace helpers"
+```
+
+---
+
+## Task 9: `GitHubToken` PAT storage
+
+**Files:**
+- Create: `frontend/src/repository/github/GitHubToken.ts`
+- Test: `frontend/src/__tests__/repository/github/GitHubToken.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import {getGitHubToken, setGitHubToken, clearGitHubToken} from '../../../repository/github/GitHubToken';
+
+describe('GitHubToken', () => {
+	afterEach(() => clearGitHubToken());
+
+	it('returns null when no token is stored', () => {
+		expect(getGitHubToken()).toBeNull();
+	});
+
+	it('stores and retrieves a token', () => {
+		setGitHubToken('ghp_example');
+		expect(getGitHubToken()).toBe('ghp_example');
+	});
+
+	it('clears a token', () => {
+		setGitHubToken('ghp_example');
+		clearGitHubToken();
+		expect(getGitHubToken()).toBeNull();
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && yarn test src/__tests__/repository/github/GitHubToken.test.ts`
+Expected: FAIL — cannot find module `GitHubToken`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+const KEY = 'owm.githubPat';
+
+// localStorage is unavailable during SSR; guard every access.
+const storage = (): Storage | null => (typeof window === 'undefined' ? null : window.localStorage);
+
+export const getGitHubToken = (): string | null => storage()?.getItem(KEY) ?? null;
+
+export const setGitHubToken = (token: string): void => {
+	storage()?.setItem(KEY, token.trim());
+};
+
+export const clearGitHubToken = (): void => {
+	storage()?.removeItem(KEY);
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && yarn test src/__tests__/repository/github/GitHubToken.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+git add frontend/src/repository/github/GitHubToken.ts frontend/src/__tests__/repository/github/GitHubToken.test.ts
+git commit -m "feat: add GitHub PAT localStorage store"
+```
+
+---
+
+## Task 10: `GitHubMapSession` holder
+
+Holds the open map's source, blob `sha`, and raw file content so the save strategy can replace the fence in place and detect stale-`sha` conflicts.
+
+**Files:**
+- Create: `frontend/src/repository/github/GitHubMapSession.ts`
+- Test: `frontend/src/__tests__/repository/github/GitHubMapSession.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import {setSession, getSession, clearSession} from '../../../repository/github/GitHubMapSession';
+
+const SAMPLE = {
+	source: {owner: 'a', repo: 'b', branch: 'main', path: 'm.md'},
+	sha: 'abc123',
+	rawFileContent: '# file',
+};
+
+describe('GitHubMapSession', () => {
+	afterEach(() => clearSession());
+
+	it('returns null when nothing is set', () => {
+		expect(getSession()).toBeNull();
+	});
+
+	it('stores and retrieves a session', () => {
+		setSession(SAMPLE);
+		expect(getSession()).toEqual(SAMPLE);
+	});
+
+	it('clears a session', () => {
+		setSession(SAMPLE);
+		clearSession();
+		expect(getSession()).toBeNull();
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && yarn test src/__tests__/repository/github/GitHubMapSession.test.ts`
+Expected: FAIL — cannot find module `GitHubMapSession`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+import {GitHubSource} from './GitHubUrl';
+
+export interface GitHubMapSession {
+	source: GitHubSource;
+	sha: string;
+	rawFileContent: string;
+}
+
+// Module-level singleton: the GitHub map is bound for the browser session
+// only. Reloading the page clears it (a known limitation — see the spec).
+let current: GitHubMapSession | null = null;
+
+export const setSession = (session: GitHubMapSession): void => {
+	current = session;
+};
+
+export const getSession = (): GitHubMapSession | null => current;
+
+export const clearSession = (): void => {
+	current = null;
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && yarn test src/__tests__/repository/github/GitHubMapSession.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+git add frontend/src/repository/github/GitHubMapSession.ts frontend/src/__tests__/repository/github/GitHubMapSession.test.ts
+git commit -m "feat: add in-memory GitHub map session holder"
+```
+
+---
+
+## Task 11: `GitHubClient`
+
+**Files:**
+- Create: `frontend/src/repository/github/GitHubClient.ts`
+- Test: `frontend/src/__tests__/repository/github/GitHubClient.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import {GitHubClient, GitHubApiError} from '../../../repository/github/GitHubClient';
+
+const SOURCE = {owner: 'a', repo: 'b', branch: 'main', path: 'm.md'};
+
+// base64 of "hello" is "aGVsbG8="
+const b64 = (s: string) => Buffer.from(s, 'utf8').toString('base64');
+
+describe('GitHubClient', () => {
+	afterEach(() => jest.restoreAllMocks());
+
+	it('readFile decodes content and returns the sha', async () => {
+		jest.spyOn(global, 'fetch').mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({content: b64('hello'), encoding: 'base64', sha: 'sha1'}),
+		} as Response);
+
+		const client = new GitHubClient('ghp_token');
+		const file = await client.readFile(SOURCE);
+		expect(file).toEqual({content: 'hello', sha: 'sha1'});
+	});
+
+	it('readFile throws GitHubApiError with the status on failure', async () => {
+		jest.spyOn(global, 'fetch').mockResolvedValue({
+			ok: false,
+			status: 404,
+			json: async () => ({message: 'Not Found'}),
+		} as Response);
+
+		const client = new GitHubClient('ghp_token');
+		await expect(client.readFile(SOURCE)).rejects.toMatchObject({
+			name: 'GitHubApiError',
+			status: 404,
+		});
+	});
+
+	it('commitFile sends the sha and returns the new sha', async () => {
+		const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({content: {sha: 'sha2'}}),
+		} as Response);
+
+		const client = new GitHubClient('ghp_token');
+		const result = await client.commitFile(SOURCE, 'new content', 'msg', 'sha1');
+		expect(result).toEqual({sha: 'sha2'});
+
+		const [, init] = fetchMock.mock.calls[0];
+		const body = JSON.parse((init as RequestInit).body as string);
+		expect(body.sha).toBe('sha1');
+		expect(body.branch).toBe('main');
+		expect(body.message).toBe('msg');
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && yarn test src/__tests__/repository/github/GitHubClient.test.ts`
+Expected: FAIL — cannot find module `GitHubClient`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+import {GitHubSource} from './GitHubUrl';
+
+export interface GitHubFile {
+	content: string;
+	sha: string;
+}
+
+export class GitHubApiError extends Error {
+	status: number;
+	constructor(status: number, message: string) {
+		super(message);
+		this.name = 'GitHubApiError';
+		this.status = status;
+	}
+}
+
+const API = 'https://api.github.com';
+
+const decodeBase64 = (b64: string): string => {
+	const bytes = Uint8Array.from(atob(b64.replace(/\s/g, '')), c => c.charCodeAt(0));
+	return new TextDecoder().decode(bytes);
+};
+
+const encodeBase64 = (text: string): string => {
+	const bytes = new TextEncoder().encode(text);
+	let binary = '';
+	bytes.forEach(b => (binary += String.fromCharCode(b)));
+	return btoa(binary);
+};
+
+export class GitHubClient {
+	private token: string;
+
+	constructor(token: string) {
+		this.token = token;
+	}
+
+	private headers(): Record<string, string> {
+		return {
+			Authorization: `Bearer ${this.token}`,
+			Accept: 'application/vnd.github+json',
+			'X-GitHub-Api-Version': '2022-11-28',
+		};
+	}
+
+	private contentsUrl(s: GitHubSource): string {
+		return `${API}/repos/${s.owner}/${s.repo}/contents/${s.path}`;
+	}
+
+	async readFile(source: GitHubSource): Promise<GitHubFile> {
+		const url = `${this.contentsUrl(source)}?ref=${encodeURIComponent(source.branch)}`;
+		const response = await fetch(url, {headers: this.headers()});
+		const data = await response.json();
+		if (!response.ok) {
+			throw new GitHubApiError(response.status, data.message || 'GitHub read failed');
+		}
+		return {content: decodeBase64(data.content), sha: data.sha};
+	}
+
+	async commitFile(
+		source: GitHubSource,
+		content: string,
+		message: string,
+		sha: string,
+	): Promise<{sha: string}> {
+		const response = await fetch(this.contentsUrl(source), {
+			method: 'PUT',
+			headers: {...this.headers(), 'Content-Type': 'application/json'},
+			body: JSON.stringify({
+				message,
+				content: encodeBase64(content),
+				sha,
+				branch: source.branch,
+			}),
+		});
+		const data = await response.json();
+		if (!response.ok) {
+			throw new GitHubApiError(response.status, data.message || 'GitHub commit failed');
+		}
+		return {sha: data.content.sha};
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && yarn test src/__tests__/repository/github/GitHubClient.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+git add frontend/src/repository/github/GitHubClient.ts frontend/src/__tests__/repository/github/GitHubClient.test.ts
+git commit -m "feat: add GitHub REST API client"
+```
+
+---
+
+## Task 12: Register the `GitHub` persistence strategy constant
+
+**Files:**
+- Modify: `frontend/src/constants/defaults.ts`
+
+- [ ] **Step 1: Add the strategy value**
+
+In `frontend/src/constants/defaults.ts`, change:
+```ts
+export const MapPersistenceStrategy = {
+	Legacy: 'Legacy',
+};
+```
+to:
+```ts
+export const MapPersistenceStrategy = {
+	Legacy: 'Legacy',
+	GitHub: 'GitHub',
+};
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+git add frontend/src/constants/defaults.ts
+git commit -m "feat: add GitHub map persistence strategy constant"
+```
+
+---
+
+## Task 13: `GitHubLoadStrategy`
+
+**Files:**
+- Create: `frontend/src/repository/GitHubLoadStrategy.ts`
+- Test: `frontend/src/__tests__/repository/github/GitHubLoadStrategy.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import {GitHubLoadStrategy} from '../../../repository/GitHubLoadStrategy';
+import {GitHubClient} from '../../../repository/github/GitHubClient';
+import {setGitHubToken, clearGitHubToken} from '../../../repository/github/GitHubToken';
+import {getSession, clearSession} from '../../../repository/github/GitHubMapSession';
+
+const FILE = ['# Map', '```mermaid', 'wardley-beta', 'component Foo [0.5, 0.5]', '```'].join('\n');
+
+describe('GitHubLoadStrategy', () => {
+	beforeEach(() => setGitHubToken('ghp_token'));
+	afterEach(() => {
+		clearGitHubToken();
+		clearSession();
+		jest.restoreAllMocks();
+	});
+
+	it('loads a map, imports it to OWM DSL, and stores the session', async () => {
+		jest.spyOn(GitHubClient.prototype, 'readFile').mockResolvedValue({content: FILE, sha: 'sha1'});
+
+		const callback = jest.fn();
+		const strategy = new GitHubLoadStrategy(callback);
+		await strategy.load('acme/maps/main/docs/tea.md');
+
+		const [strategyName, data] = callback.mock.calls[0];
+		expect(strategyName).toBe('GitHub');
+		expect(data.mapText).toContain('component Foo [0.5, 0.5]');
+		expect(data.mapText).not.toContain('wardley-beta');
+		expect(getSession()?.sha).toBe('sha1');
+	});
+
+	it('throws when no token is stored', async () => {
+		clearGitHubToken();
+		const strategy = new GitHubLoadStrategy(jest.fn());
+		await expect(strategy.load('acme/maps/main/tea.md')).rejects.toThrow(/token/i);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && yarn test src/__tests__/repository/github/GitHubLoadStrategy.test.ts`
+Expected: FAIL — cannot find module `GitHubLoadStrategy`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+import {importFromMermaid} from '../conversion/mermaid/MermaidImporter';
+import * as Defaults from '../constants/defaults';
+import {GitHubClient} from './github/GitHubClient';
+import {extractMermaidFence} from './github/MermaidFence';
+import {setSession} from './github/GitHubMapSession';
+import {getGitHubToken} from './github/GitHubToken';
+import {idToSource} from './github/GitHubUrl';
+import {LoadStrategy} from './LoadStrategy';
+
+export class GitHubLoadStrategy extends LoadStrategy {
+	async load(id: string): Promise<void> {
+		const token = getGitHubToken();
+		if (!token) {
+			throw new Error('No GitHub token configured. Add a personal access token first.');
+		}
+
+		const source = idToSource(id);
+		const client = new GitHubClient(token);
+		const file = await client.readFile(source);
+
+		const {body} = extractMermaidFence(file.content);
+		const mapText = importFromMermaid(body);
+
+		setSession({source, sha: file.sha, rawFileContent: file.content});
+
+		this.callback(Defaults.MapPersistenceStrategy.GitHub, {
+			id,
+			mapText,
+			mapIterations: [],
+		});
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && yarn test src/__tests__/repository/github/GitHubLoadStrategy.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+git add frontend/src/repository/GitHubLoadStrategy.ts frontend/src/__tests__/repository/github/GitHubLoadStrategy.test.ts
+git commit -m "feat: add GitHubLoadStrategy"
+```
+
+---
+
+## Task 14: `GitHubSaveStrategy`
+
+**Files:**
+- Create: `frontend/src/repository/GitHubSaveStrategy.ts`
+- Test: `frontend/src/__tests__/repository/github/GitHubSaveStrategy.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import {GitHubSaveStrategy} from '../../../repository/GitHubSaveStrategy';
+import {GitHubClient} from '../../../repository/github/GitHubClient';
+import {setSession, getSession, clearSession} from '../../../repository/github/GitHubMapSession';
+
+const FILE = ['# Map', '```mermaid', 'wardley-beta', 'component Foo [0.5, 0.5]', '```'].join('\n');
+
+const map = (mapText: string) => ({readOnly: false, mapText, imageData: '', mapIterations: []});
+
+describe('GitHubSaveStrategy', () => {
+	beforeEach(() => {
+		setSession({
+			source: {owner: 'a', repo: 'b', branch: 'main', path: 'm.md'},
+			sha: 'sha1',
+			rawFileContent: FILE,
+		});
+		jest.spyOn(window, 'prompt').mockReturnValue('Update map');
+	});
+	afterEach(() => {
+		clearSession();
+		jest.restoreAllMocks();
+	});
+
+	it('commits the regenerated fence and updates the session sha', async () => {
+		const commit = jest
+			.spyOn(GitHubClient.prototype, 'commitFile')
+			.mockResolvedValue({sha: 'sha2'});
+
+		const callback = jest.fn();
+		await new GitHubSaveStrategy(callback).save(map('component Bar [0.1, 0.2]'), 'a/b/main/m.md');
+
+		const committedContent = commit.mock.calls[0][1];
+		expect(committedContent).toContain('component Bar [0.1, 0.2]');
+		expect(committedContent).toContain('# Map'); // prose preserved
+		expect(commit.mock.calls[0][3]).toBe('sha1'); // sha sent
+		expect(getSession()?.sha).toBe('sha2'); // sha updated
+		expect(callback).toHaveBeenCalled();
+	});
+
+	it('aborts when the user cancels the commit-message prompt', async () => {
+		jest.spyOn(window, 'prompt').mockReturnValue(null);
+		const commit = jest.spyOn(GitHubClient.prototype, 'commitFile');
+		await new GitHubSaveStrategy(jest.fn()).save(map('component Bar [0.1, 0.2]'), 'a/b/main/m.md');
+		expect(commit).not.toHaveBeenCalled();
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && yarn test src/__tests__/repository/github/GitHubSaveStrategy.test.ts`
+Expected: FAIL — cannot find module `GitHubSaveStrategy`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+import {exportToMermaid} from '../conversion/mermaid/MermaidExporter';
+import {GitHubClient} from './github/GitHubClient';
+import {getGitHubToken} from './github/GitHubToken';
+import {getSession, setSession} from './github/GitHubMapSession';
+import {replaceMermaidFence} from './github/MermaidFence';
+import {OwnApiWardleyMap} from './OwnApiWardleyMap';
+import {SaveStrategy} from './SaveStrategy';
+
+export class GitHubSaveStrategy implements SaveStrategy {
+	callback: (id: string, data: string) => void;
+
+	constructor(callback: (id: string, data: string) => void) {
+		this.callback = callback;
+	}
+
+	async save(map: OwnApiWardleyMap, hash: string): Promise<void> {
+		const token = getGitHubToken();
+		const session = getSession();
+		if (!token || !session) {
+			throw new Error('No GitHub map is open. Open a map from GitHub before saving.');
+		}
+
+		const message = window.prompt('Commit message', 'Update Wardley map via OnlineWardleyMaps');
+		if (message === null) return; // user cancelled
+
+		const {mermaid} = exportToMermaid(map.mapText);
+		const newFileContent = replaceMermaidFence(session.rawFileContent, mermaid);
+
+		const client = new GitHubClient(token);
+		const result = await client.commitFile(session.source, newFileContent, message, session.sha);
+
+		setSession({...session, sha: result.sha, rawFileContent: newFileContent});
+		this.callback(hash, JSON.stringify({id: hash}));
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && yarn test src/__tests__/repository/github/GitHubSaveStrategy.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+git add frontend/src/repository/GitHubSaveStrategy.ts frontend/src/__tests__/repository/github/GitHubSaveStrategy.test.ts
+git commit -m "feat: add GitHubSaveStrategy"
+```
+
+---
+
+## Task 15: Register strategies in `LoadMap` and `SaveMap`
+
+**Files:**
+- Modify: `frontend/src/repository/LoadMap.ts`
+- Modify: `frontend/src/repository/SaveMap.ts`
+
+- [ ] **Step 1: Wire `LoadMap.ts`**
+
+In `frontend/src/repository/LoadMap.ts`, add an import:
+```ts
+import {GitHubLoadStrategy} from './GitHubLoadStrategy';
+```
+In the `loadStrategy` record, add a second entry so it reads:
+```ts
+const loadStrategy: Record<string, () => LoadStrategy> = {
+	[Defaults.MapPersistenceStrategy.Legacy]: () => new LegacyLoadStrategy(followOnActions),
+	[Defaults.MapPersistenceStrategy.GitHub]: () => new GitHubLoadStrategy(followOnActions),
+};
+```
+
+- [ ] **Step 2: Wire `SaveMap.ts`**
+
+In `frontend/src/repository/SaveMap.ts`, add an import:
+```ts
+import {GitHubSaveStrategy} from './GitHubSaveStrategy';
+```
+In the `switch (mapPersistenceStrategy)` block, add a case after the `Legacy` case:
+```ts
+		case Defaults.MapPersistenceStrategy.GitHub:
+			loadedSaveStrategy = new GitHubSaveStrategy(callback);
+			break;
+```
+
+- [ ] **Step 3: Type-check and run the repository tests**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no new errors.
+
+Run: `cd frontend && yarn test src/__tests__/repository`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+git add frontend/src/repository/LoadMap.ts frontend/src/repository/SaveMap.ts
+git commit -m "feat: register GitHub load/save strategies in dispatchers"
+```
+
+---
+
+## Task 16: `OpenFromGitHubDialog` component
+
+A MUI dialog with a GitHub URL field, a PAT field (shown only when no token is stored), and validation.
+
+**Files:**
+- Create: `frontend/src/components/github/OpenFromGitHubDialog.tsx`
+- Test: `frontend/src/components/github/OpenFromGitHubDialog.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import {fireEvent, render, screen} from '@testing-library/react';
+import OpenFromGitHubDialog from './OpenFromGitHubDialog';
+import {clearGitHubToken, getGitHubToken, setGitHubToken} from '../../repository/github/GitHubToken';
+
+describe('OpenFromGitHubDialog', () => {
+	afterEach(() => clearGitHubToken());
+
+	it('rejects an invalid URL without calling onOpen', () => {
+		const onOpen = jest.fn();
+		setGitHubToken('ghp_token');
+		render(<OpenFromGitHubDialog open onClose={jest.fn()} onOpen={onOpen} />);
+
+		fireEvent.change(screen.getByLabelText(/github file url/i), {target: {value: 'not a url'}});
+		fireEvent.click(screen.getByRole('button', {name: /^open$/i}));
+
+		expect(onOpen).not.toHaveBeenCalled();
+		expect(screen.getByText(/not a valid github/i)).toBeInTheDocument();
+	});
+
+	it('calls onOpen with the id and stores the PAT for a valid URL', () => {
+		const onOpen = jest.fn();
+		render(<OpenFromGitHubDialog open onClose={jest.fn()} onOpen={onOpen} />);
+
+		fireEvent.change(screen.getByLabelText(/personal access token/i), {
+			target: {value: 'ghp_new'},
+		});
+		fireEvent.change(screen.getByLabelText(/github file url/i), {
+			target: {value: 'https://github.com/acme/maps/blob/main/docs/tea.md'},
+		});
+		fireEvent.click(screen.getByRole('button', {name: /^open$/i}));
+
+		expect(onOpen).toHaveBeenCalledWith('acme/maps/main/docs/tea.md');
+		expect(getGitHubToken()).toBe('ghp_new');
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && yarn test src/components/github/OpenFromGitHubDialog.test.tsx`
+Expected: FAIL — cannot find module `OpenFromGitHubDialog`.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Link from '@mui/material/Link';
+import TextField from '@mui/material/TextField';
+import React, {FunctionComponent, useState} from 'react';
+import {parseGitHubUrl, sourceToId} from '../../repository/github/GitHubUrl';
+import {getGitHubToken, setGitHubToken} from '../../repository/github/GitHubToken';
+
+interface OpenFromGitHubDialogProps {
+	open: boolean;
+	onClose: () => void;
+	onOpen: (id: string) => void;
+}
+
+const OpenFromGitHubDialog: FunctionComponent<OpenFromGitHubDialogProps> = ({open, onClose, onOpen}) => {
+	const hasToken = getGitHubToken() !== null;
+	const [url, setUrl] = useState('');
+	const [token, setToken] = useState('');
+	const [error, setError] = useState('');
+
+	const handleOpen = () => {
+		const source = parseGitHubUrl(url);
+		if (!source) {
+			setError('That is not a valid GitHub file URL (expected .../blob/...).');
+			return;
+		}
+		if (!hasToken && token.trim() === '') {
+			setError('A personal access token is required.');
+			return;
+		}
+		if (token.trim() !== '') setGitHubToken(token);
+		setError('');
+		onOpen(sourceToId(source));
+		onClose();
+	};
+
+	return (
+		<Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+			<DialogTitle>Open map from GitHub</DialogTitle>
+			<DialogContent>
+				<DialogContentText sx={{mb: 2}}>
+					Paste a link to a Markdown file containing a Mermaid <code>wardley-beta</code> block.
+				</DialogContentText>
+				<TextField
+					autoFocus
+					fullWidth
+					margin="dense"
+					label="GitHub file URL"
+					placeholder="https://github.com/owner/repo/blob/branch/path.md"
+					value={url}
+					onChange={e => setUrl(e.target.value)}
+				/>
+				{!hasToken && (
+					<TextField
+						fullWidth
+						margin="dense"
+						type="password"
+						label="Personal access token"
+						helperText={
+							<>
+								Needs Contents: read &amp; write.{' '}
+								<Link
+									href="https://github.com/settings/personal-access-tokens"
+									target="_blank"
+									rel="noreferrer">
+									Create one
+								</Link>
+								.
+							</>
+						}
+						value={token}
+						onChange={e => setToken(e.target.value)}
+					/>
+				)}
+				{error !== '' && (
+					<DialogContentText color="error" sx={{mt: 1}}>
+						{error}
+					</DialogContentText>
+				)}
+			</DialogContent>
+			<DialogActions>
+				<Button onClick={onClose}>Cancel</Button>
+				<Button onClick={handleOpen} variant="contained">
+					Open
+				</Button>
+			</DialogActions>
+		</Dialog>
+	);
+};
+
+export default OpenFromGitHubDialog;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && yarn test src/components/github/OpenFromGitHubDialog.test.tsx`
+Expected: PASS. If `getByLabelText` fails to match, confirm the `label` text in the test matches the `TextField` `label` prop.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+git add frontend/src/components/github/OpenFromGitHubDialog.tsx frontend/src/components/github/OpenFromGitHubDialog.test.tsx
+git commit -m "feat: add Open from GitHub dialog"
+```
+
+---
+
+## Task 17: Wire the dialog into the header
+
+Threads an `openFromGitHub` callback from `MapEnvironment` (which owns the persistence state) through `MapLayout` to `NewHeader`, and adds an "Open from GitHub…" menu item that shows the dialog.
+
+**Files:**
+- Modify: `frontend/src/components/MapEnvironment.tsx`
+- Modify: `frontend/src/components/map/components/MapLayout.tsx`
+- Modify: `frontend/src/components/page/NewHeader.tsx`
+
+- [ ] **Step 1: Add the `openFromGitHub` callback in `MapEnvironment.tsx`**
+
+In `frontend/src/components/MapEnvironment.tsx`, add a `useCallback` near the other persistence callbacks (it must be after `setMapPersistenceStrategy`, `setCurrentId`, and `setShouldLoad` are in scope — they already are, per the `useMapPersistence` props block around line 308):
+
+```tsx
+const openFromGitHub = useCallback(
+	(id: string) => {
+		setMapPersistenceStrategy(Defaults.MapPersistenceStrategy.GitHub);
+		setCurrentId(id);
+		setShouldLoad(true);
+	},
+	[setMapPersistenceStrategy, setCurrentId, setShouldLoad],
+);
+```
+
+If `Defaults` is not already imported in this file, add `import * as Defaults from '../constants/defaults';` with the other imports. (The existing `useEffect` at line ~392 — `if (shouldLoad) mapPersistence.loadFromRemoteStorage()` — then performs the load.)
+
+Then in the `<MapLayout ... />` element (around line 715), add the prop:
+```tsx
+openFromGitHub={openFromGitHub}
+```
+
+- [ ] **Step 2: Pass the prop through `MapLayout.tsx`**
+
+In `frontend/src/components/map/components/MapLayout.tsx`:
+
+1. In the props interface (the one containing `newMapClick: (strategy: string) => void;` near line 32), add:
+   ```tsx
+   openFromGitHub: (id: string) => void;
+   ```
+2. In the destructured props (near line 77, where `newMapClick` is listed), add `openFromGitHub,`.
+3. In the `<NewHeader ... />` element (near line 122), add the prop:
+   ```tsx
+   openFromGitHub={openFromGitHub}
+   ```
+
+- [ ] **Step 3: Add the prop and menu item in `NewHeader.tsx`**
+
+In `frontend/src/components/page/NewHeader.tsx`:
+
+1. In `NewHeaderProps`, add:
+   ```tsx
+   openFromGitHub: (id: string) => void;
+   ```
+2. In the destructured props of the `NewHeader` component, add `openFromGitHub,`.
+3. Add an import at the top:
+   ```tsx
+   import OpenFromGitHubDialog from '../github/OpenFromGitHubDialog';
+   ```
+4. Next to the existing `const [modalShow, setModalShow] = useState(false);`, add:
+   ```tsx
+   const [gitHubDialogShow, setGitHubDialogShow] = useState(false);
+   ```
+5. Inside the `StyledMenu` (`moreMenu`), add a new menu item as the first child, before the existing first `<MenuItem>`:
+   ```tsx
+   <MenuItem disableRipple onClick={() => handleMoreClose(() => setGitHubDialogShow(true))}>
+   	Open from GitHub…
+   </MenuItem>
+   ```
+6. Render the dialog. Find where `moreMenu` is returned/used in the component's JSX and add the dialog as a sibling element (e.g. immediately after `{moreMenu}` or inside the same fragment):
+   ```tsx
+   <OpenFromGitHubDialog
+   	open={gitHubDialogShow}
+   	onClose={() => setGitHubDialogShow(false)}
+   	onOpen={openFromGitHub}
+   />
+   ```
+
+- [ ] **Step 4: Type-check, lint, and run the full test suite**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no errors.
+
+Run: `cd frontend && yarn lint`
+Expected: no errors.
+
+Run: `cd frontend && yarn test`
+Expected: PASS — all tests, including the new converter, repository, and dialog suites.
+
+- [ ] **Step 5: Manual smoke test**
+
+Run: `cd frontend && yarn dev`
+Then in the browser at http://localhost:3000:
+1. Open the overflow (⋮) menu → "Open from GitHub…".
+2. Paste a URL to a Markdown file with a `wardley-beta` fence and a fine-grained PAT.
+3. Confirm the map loads and renders.
+4. Edit the map text, click Save, accept the commit-message prompt.
+5. Confirm the commit appears on GitHub with the fence updated and surrounding prose intact.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /workspaces/onlinewardleymaps-rebrand
+git add frontend/src/components/MapEnvironment.tsx frontend/src/components/map/components/MapLayout.tsx frontend/src/components/page/NewHeader.tsx
+git commit -m "feat: wire Open from GitHub dialog into the header menu"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Component 1 (converter) → Tasks 1-6; Component 2 (GitHub access) → Tasks 7-11; Component 3 (persistence wiring & UI) → Tasks 12-17. Error handling — `GitHubApiError` carries the status (Task 11) for the load/save callers to surface; the dialog shows inline URL/token errors (Task 16); the stale-`sha` `409` surfaces as a `GitHubApiError` from `commitFile`. `keptAsComments` is produced (Task 3) and available to callers for the "won't render on GitHub" warning.
+- **Type consistency:** `GitHubSource` (Task 7) is reused by `GitHubMapSession`, `GitHubClient`, and both strategies. `exportToMermaid` returns `{mermaid, keptAsComments}` consistently (Tasks 2/3) and is consumed by `GitHubSaveStrategy` (Task 14). `importFromMermaid` returns a `string` consumed by `GitHubLoadStrategy` (Task 13).
+- **Known follow-up (out of scope, per spec):** the `keptAsComments` warning is not yet shown in the UI on save, and there is no hash deep-linking — reloading the page loses the GitHub binding. Both are noted in the design spec as future enhancements.

--- a/docs/superpowers/specs/2026-05-20-github-mermaid-wardley-beta-design.md
+++ b/docs/superpowers/specs/2026-05-20-github-mermaid-wardley-beta-design.md
@@ -1,0 +1,224 @@
+# GitHub + Mermaid wardley-beta support — Design
+
+**Date:** 2026-05-20
+**Target codebase:** `ai-rebrand` — `frontend/` (Next.js 16, TypeScript)
+**Target Mermaid version:** 11.15.0
+
+## Overview
+
+Let a user open a Wardley map that is stored as a **Mermaid `wardley-beta`** code
+fence inside a file in a GitHub repository, edit it in OnlineWardleyMaps (OWM),
+and commit the changes back to the same file.
+
+Mermaid's `wardley-beta` diagram type (shipped in Mermaid 11.14.0, refined in
+11.15.0) deliberately adopted OWM's `[visibility, evolution]` coordinate format
+and keyword names. GitHub renders `wardley-beta` fences natively. This makes a
+GitHub repo a viable, human-readable, version-controlled store for Wardley maps —
+the map is both editable in OWM and visible in the repo.
+
+The feature is two independent pieces:
+
+1. A **bidirectional Mermaid converter** (OWM DSL ↔ Mermaid `wardley-beta`).
+2. A **GitHub persistence strategy** that plugs into the existing
+   `LoadMap` / `SaveMap` strategy dispatchers in `frontend/src/repository/`.
+
+## Goals
+
+- Open a map from a GitHub file URL pasted by the user.
+- Edit it as a normal OWM map.
+- Commit the edited map back to the same file on the same branch.
+- Preserve any prose surrounding the fence in a Markdown file.
+- Lose no map data on a GitHub round-trip, even for OWM features Mermaid
+  cannot render.
+
+## Non-goals (YAGNI — explicitly out of scope)
+
+- OAuth sign-in, GitHub App installation.
+- A repo file browser / tree navigator.
+- Pull-request or branch-creation flows.
+- Hash deep-linking (`#github:...`). Noted as a future enhancement. Consequence:
+  **reloading the browser loses the in-memory GitHub binding** and the user must
+  re-paste the URL to save again.
+- More than one `wardley-beta` fence per file (only the first is used).
+
+## Decisions captured during brainstorming
+
+| Topic | Decision |
+|---|---|
+| Core capability | GitHub repo integration (load + commit-back). |
+| Repo storage format | Mermaid `wardley-beta` is the canonical stored format. |
+| Auth | Fine-grained Personal Access Token (PAT) pasted by the user. No backend OAuth. |
+| Open flow | Paste a `github.com/.../blob/...` URL. |
+| Save flow | Regenerate the fence, commit directly to the same file/branch, prompting for a commit message. |
+| Unsupported OWM keywords on export | Kept as `%%` Mermaid comments (lossless round-trip). |
+| Converter origin | Port the validated `tools/convert.mjs` from `tractorjuice/wardley-maps-mermaid` to TypeScript, modified to emit comments instead of dropping. |
+
+## Architecture
+
+### Component 1 — Mermaid converter (`frontend/src/conversion/mermaid/`)
+
+Because Mermaid `wardley-beta` reuses OWM's coordinate format and keyword names,
+the converter body is largely a pass-through.
+
+#### `MermaidExporter.ts` — OWM `mapText` → Mermaid `wardley-beta`
+
+Ported to TypeScript from `owmToMermaid()` in
+[`tractorjuice/wardley-maps-mermaid` `tools/convert.mjs`](https://github.com/tractorjuice/wardley-maps-mermaid/blob/main/tools/convert.mjs).
+That converter is validated: 147/147 maps parse and render with the real Mermaid
+11.15.0 parser, and `test-fidelity.mjs` reports 100% component/anchor/link
+retention with `|Δε| = 0` across 4,905 matched element pairs.
+
+Behaviour carried over from the original:
+
+- Emit `wardley-beta` as the first line, followed by `title` and an
+  auto-injected `size [1100, 800]`.
+- Pass through keywords shared with OWM: `title`, `size`, `component`, `anchor`,
+  `evolve`, `pipeline`, `evolution`, `note`, `annotation` / `annotations`,
+  links / flow, inertia, sourcing decorators (`(build)`, `(buy)`, `(outsource)`).
+- Conservative name quoting (the `convert.mjs` quoting rules): names that match
+  the safe regex are left unquoted; all others are double-quoted with internal
+  quotes escaped.
+- Pipeline child detection (explicit `{}` blocks open a Mermaid pipeline scope;
+  implicit proximity-detected children are auto-injected).
+- `evolve` number-safety reformatting (position is a number followed by
+  whitespace/EOL, so names like `Lamp / .Net` do not misparse).
+- Strip `//` line comments and `/* */` blocks; collapse consecutive blank lines.
+
+**The one behavioural change from the original:** OWM keywords with no
+`wardley-beta` equivalent — `market`, `ecosystem`, `submap`, `url`,
+`pioneers` / `settlers` / `townplanners`, `accelerator`, `style`,
+`x-axis` / `y-axis` — are **emitted as `%% <original line>` Mermaid comments**
+rather than silently dropped. This makes the export lossless on a round-trip.
+
+Signature:
+
+```ts
+function exportToMermaid(
+  mapText: string,
+  titleFallback?: string,
+): { mermaid: string; keptAsComments: string[] };
+```
+
+`keptAsComments` lists the original lines preserved as comments, so the UI can
+warn the user which parts of the map GitHub will not render.
+
+#### `MermaidImporter.ts` — Mermaid `wardley-beta` → OWM `mapText`
+
+New, thin:
+
+1. Strip the `wardley-beta` header line.
+2. Un-comment `%%` lines whose body begins with a known OWM keyword (restoring
+   what `MermaidExporter` preserved). `%%` comments that are not restorable OWM
+   keywords are discarded.
+3. Hand the resulting body to the existing `Converter` unchanged — the body is
+   already valid OWM DSL.
+
+Signature:
+
+```ts
+function importFromMermaid(mermaidText: string): string; // returns OWM mapText
+```
+
+Both functions are pure and re-exported via `frontend/wmlandscape/src/index.js`
+so the VSCode and Obsidian extensions can use them.
+
+### Component 2 — GitHub access (`frontend/src/repository/github/`)
+
+#### `GitHubUrl.ts`
+
+Pure parser. `github.com/{owner}/{repo}/blob/{branch}/{path}` →
+`{ owner, repo, branch, path }`. Returns a typed error for unrecognised URLs.
+
+#### `GitHubClient.ts`
+
+Thin wrapper over the GitHub REST API using browser `fetch` (the GitHub API is
+CORS-enabled). Carries the PAT in the `Authorization` header.
+
+- Read: `GET /repos/{owner}/{repo}/contents/{path}?ref={branch}` — returns the
+  file content (base64) and its blob `sha`.
+- Commit: `PUT /repos/{owner}/{repo}/contents/{path}` with the new content,
+  commit message, `branch`, and the existing `sha`.
+
+#### `MermaidFence.ts`
+
+- `extractFence(fileContent)` — locate the first ` ```mermaid ` fence whose body
+  starts with `wardley-beta`; return the fence body plus enough position
+  information to put it back.
+- `replaceFence(fileContent, newBody)` — substitute the fence body, leaving all
+  surrounding Markdown prose intact.
+- A file with no fence (e.g. a bare `.wm`) is treated as the whole map body.
+
+#### PAT storage
+
+The token is stored in `localStorage` under `owm.githubPat` and is sent only to
+`api.github.com`. A small settings dialog lets the user enter or clear it, links
+to GitHub's fine-grained PAT creation page, and states the required scope:
+**Contents — Read and write** on the target repository.
+
+### Component 3 — Persistence wiring & UI
+
+- Add `MapPersistenceStrategy.GitHub = 'GitHub'` to
+  `frontend/src/constants/defaults.ts`.
+- `GitHubLoadStrategy implements LoadStrategy` — given an id of
+  `owner/repo/branch/path`: read the file, `extractFence`, `importFromMermaid`,
+  run `followOnActions` to load the map.
+- `GitHubSaveStrategy implements SaveStrategy` — `exportToMermaid`,
+  `replaceFence` into the original file content, `PUT` commit with the stored
+  `sha`. Prompts for a commit message (default e.g.
+  `Update Wardley map: <title>`).
+- Register both in the `LoadMap` and `SaveMap` dispatchers.
+- "Open from GitHub" menu item opens a dialog with a URL field and, if no PAT is
+  stored, a PAT field. The GitHub source (`owner/repo/branch/path` plus the file
+  `sha`) is held in the in-memory persistence state for the session.
+
+## Data flow
+
+**Open:** paste URL → `GitHubUrl.parse` → `GitHubClient.read` → `extractFence`
+→ `importFromMermaid` → `Converter` → map renders. Persistence strategy set to
+`GitHub`; source + `sha` retained in memory.
+
+**Save:** user edits → `exportToMermaid(mapText)` → `replaceFence` into the
+original file content → `GitHubClient.commit` with the stored `sha` → on success
+the returned new `sha` replaces the stored one (so consecutive saves work).
+
+## Error handling
+
+| Condition | Behaviour |
+|---|---|
+| Unrecognised GitHub URL | Inline error in the open dialog. |
+| `401` / `403` | "Token missing or lacks Contents write permission." |
+| `404` | "File or branch not found." |
+| No `wardley-beta` fence in a Markdown file | Prompt: treat the whole file as the map, or cancel. |
+| Save `409` / stale `sha` | "The file changed on GitHub since you opened it — reload before saving." |
+| Mermaid import parse failure | Surfaced through the existing `ParseError` UI. |
+| `keptAsComments` non-empty after export | Non-blocking warning listing lines GitHub will not render. |
+
+## Testing
+
+- **Unit — `MermaidExporter`**: port the fidelity expectations from
+  `convert.mjs`; assert unsupported keywords become `%%` comments and are
+  reported in `keptAsComments`.
+- **Unit — `MermaidImporter`**: header stripping; `%%` un-commenting of OWM
+  keywords; discard of non-restorable comments.
+- **Round-trip suite**: OWM → Mermaid → OWM equals the original, including the
+  comment round-trip of unsupported keywords. Use real example maps.
+- **Unit — `GitHubUrl`**: valid/invalid URL parsing.
+- **Unit — `MermaidFence`**: extract/replace with surrounding prose preserved;
+  no-fence fallback.
+- **`GitHubClient`, `GitHubLoadStrategy`, `GitHubSaveStrategy`**: tested against
+  a mocked `fetch` / client (success, `401`, `404`, `409`).
+
+## Open risks
+
+- **`convert.mjs` is export-only.** No reference importer exists; `MermaidImporter`
+  is written fresh. Mitigated by the round-trip test suite.
+- **Pipeline visibility drift.** The source converter notes a grammar-level mean
+  `|Δν| = 0.008` because `wardley-beta` pipeline children inherit parent
+  visibility. This is inherent to the format and accepted.
+- **PAT in `localStorage`** is readable by any script on the OWM origin. Accepted
+  for a fine-grained, repo-scoped token; documented in the settings dialog.
+
+## References
+
+- Mermaid Wardley syntax: <https://mermaid.js.org/syntax/wardley.html>
+- Existing converter: <https://github.com/tractorjuice/wardley-maps-mermaid/tree/main/tools>

--- a/frontend/.jest/jsdom-with-fetch-env.js
+++ b/frontend/.jest/jsdom-with-fetch-env.js
@@ -1,0 +1,27 @@
+/**
+ * Custom Jest environment that extends jsdom and exposes Node's native fetch
+ * on global so that jest.spyOn(global, 'fetch') works.
+ *
+ * Node 18+ has fetch built in; jest-environment-jsdom does not forward it into
+ * the sandbox. This environment copies it in during setup().
+ */
+const {TestEnvironment} = require('jest-environment-jsdom');
+
+class JsdomWithFetchEnvironment extends TestEnvironment {
+    async setup() {
+        await super.setup();
+        // Expose Node's native fetch inside the jsdom sandbox
+        if (typeof fetch !== 'undefined') {
+            this.global.fetch = fetch;
+        }
+        // Expose TextEncoder/TextDecoder (Node globals not forwarded by jsdom)
+        if (typeof TextEncoder !== 'undefined') {
+            this.global.TextEncoder = TextEncoder;
+        }
+        if (typeof TextDecoder !== 'undefined') {
+            this.global.TextDecoder = TextDecoder;
+        }
+    }
+}
+
+module.exports = JsdomWithFetchEnvironment;

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
         '@/(.*)$': '<rootDir>/src/$1',
     },
     setupFilesAfterEnv: ['<rootDir>/.jest/register-context.js', '<rootDir>/src/setupTests.js'],
-    testEnvironment: 'jsdom',
+    testEnvironment: '<rootDir>/.jest/jsdom-with-fetch-env.js',
     transform: {
         '^.+\\.(ts|tsx|js|jsx)$': ['babel-jest', {presets: ['next/babel']}],
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -120,8 +120,8 @@
         "package": "yarn --cwd wmlandscape build",
         "package:pack": "yarn --cwd wmlandscape pack:check",
         "package:publish": "cd wmlandscape && npm publish --registry https://registry.npmjs.org/ --access public",
-        "test": "jest --env=jsdom",
-        "test:watch": "jest --watchAll --env=jsdom",
+        "test": "jest",
+        "test:watch": "jest --watchAll",
         "sonar": "node sonar-project.js"
     },
     "browserslist": {

--- a/frontend/src/__tests__/conversion/mermaid/MermaidExporter.test.ts
+++ b/frontend/src/__tests__/conversion/mermaid/MermaidExporter.test.ts
@@ -1,0 +1,13 @@
+import {exportToMermaid} from '../../../conversion/mermaid/MermaidExporter';
+
+describe('exportToMermaid', () => {
+    it('emits a wardley-beta header', () => {
+        const result = exportToMermaid('title Test\ncomponent Foo [0.5, 0.5]');
+        expect(result.mermaid.split('\n')[0]).toBe('wardley-beta');
+    });
+
+    it('passes a component through unchanged', () => {
+        const result = exportToMermaid('component Foo [0.5, 0.5]');
+        expect(result.mermaid).toContain('component Foo [0.5, 0.5]');
+    });
+});

--- a/frontend/src/__tests__/conversion/mermaid/MermaidExporter.test.ts
+++ b/frontend/src/__tests__/conversion/mermaid/MermaidExporter.test.ts
@@ -11,3 +11,16 @@ describe('exportToMermaid', () => {
         expect(result.mermaid).toContain('component Foo [0.5, 0.5]');
     });
 });
+
+describe('exportToMermaid — unsupported keywords', () => {
+    it('preserves a market line as a %% comment', () => {
+        const result = exportToMermaid('component Foo [0.5, 0.5]\nmarket Buyers [0.9, 0.5]');
+        expect(result.mermaid).toContain('%% market Buyers [0.9, 0.5]');
+        expect(result.keptAsComments).toContain('market Buyers [0.9, 0.5]');
+    });
+
+    it('does not list normal lines in keptAsComments', () => {
+        const result = exportToMermaid('component Foo [0.5, 0.5]');
+        expect(result.keptAsComments).toEqual([]);
+    });
+});

--- a/frontend/src/__tests__/conversion/mermaid/MermaidImporter.test.ts
+++ b/frontend/src/__tests__/conversion/mermaid/MermaidImporter.test.ts
@@ -1,0 +1,24 @@
+import {importFromMermaid} from '../../../conversion/mermaid/MermaidImporter';
+
+describe('importFromMermaid', () => {
+    it('strips the wardley-beta header line', () => {
+        const owm = importFromMermaid('wardley-beta\ncomponent Foo [0.5, 0.5]');
+        expect(owm).not.toContain('wardley-beta');
+        expect(owm).toContain('component Foo [0.5, 0.5]');
+    });
+
+    it('strips the auto-injected size line', () => {
+        const owm = importFromMermaid('wardley-beta\ntitle T\nsize [1100, 800]\ncomponent Foo [0.5, 0.5]');
+        expect(owm).not.toContain('size [1100, 800]');
+    });
+
+    it('restores OWM-only keywords from %% comments', () => {
+        const owm = importFromMermaid('wardley-beta\n%% market Buyers [0.9, 0.5]\ncomponent Foo [0.5, 0.5]');
+        expect(owm).toContain('market Buyers [0.9, 0.5]');
+    });
+
+    it('drops %% comments that are not OWM keywords', () => {
+        const owm = importFromMermaid('wardley-beta\n%% just a note\ncomponent Foo [0.5, 0.5]');
+        expect(owm).not.toContain('just a note');
+    });
+});

--- a/frontend/src/__tests__/conversion/mermaid/owmOnlyKeywords.test.ts
+++ b/frontend/src/__tests__/conversion/mermaid/owmOnlyKeywords.test.ts
@@ -1,0 +1,31 @@
+import {isOwmOnlyLine} from '../../../conversion/mermaid/owmOnlyKeywords';
+
+describe('isOwmOnlyLine', () => {
+    it.each([
+        'style wardley',
+        'build Foo',
+        'x-axis Genesis -> Commodity',
+        'y-axis Value -> Invisible',
+        'market Customers [0.9, 0.5]',
+        'ecosystem Things [0.5, 0.5]',
+        'submap Foo [0.5, 0.5]',
+        'url foo https://example.com',
+        'pioneers [0.1, 0.1, 0.2, 0.2]',
+        'explorers [0.1, 0.1, 0.2, 0.2]',
+        'villagers [0.5, 0.5, 0.6, 0.6]',
+        'accelerator Speed [0.5, 0.5]',
+    ])('treats "%s" as an OWM-only line', line => {
+        expect(isOwmOnlyLine(line)).toBe(true);
+    });
+
+    it.each([
+        'component Foo [0.5, 0.5]',
+        'anchor User [0.9, 0.9]',
+        'Market segmentation -> Last Mile',
+        'Pioneer programme -> Funding',
+        'evolve Kettle 0.62',
+        '',
+    ])('treats "%s" as a normal line', line => {
+        expect(isOwmOnlyLine(line)).toBe(false);
+    });
+});

--- a/frontend/src/__tests__/conversion/mermaid/owmOnlyKeywords.test.ts
+++ b/frontend/src/__tests__/conversion/mermaid/owmOnlyKeywords.test.ts
@@ -3,6 +3,8 @@ import {isOwmOnlyLine} from '../../../conversion/mermaid/owmOnlyKeywords';
 describe('isOwmOnlyLine', () => {
     it.each([
         'style wardley',
+        'style colour',
+        'style handwritten',
         'build Foo',
         'x-axis Genesis -> Commodity',
         'y-axis Value -> Invisible',
@@ -24,6 +26,7 @@ describe('isOwmOnlyLine', () => {
         'Market segmentation -> Last Mile',
         'Pioneer programme -> Funding',
         'evolve Kettle 0.62',
+        'style guide -> Funding',
         '',
     ])('treats "%s" as a normal line', line => {
         expect(isOwmOnlyLine(line)).toBe(false);

--- a/frontend/src/__tests__/conversion/mermaid/roundTrip.test.ts
+++ b/frontend/src/__tests__/conversion/mermaid/roundTrip.test.ts
@@ -1,0 +1,39 @@
+import {exportToMermaid} from '../../../conversion/mermaid/MermaidExporter';
+import {importFromMermaid} from '../../../conversion/mermaid/MermaidImporter';
+
+// Normalise for comparison: drop blank lines and trim each line. The
+// exporter intentionally collapses blanks and strips `//` comments.
+const normalise = (text: string): string[] =>
+    text
+        .split('\n')
+        .map(l => l.trim())
+        .filter(l => l.length > 0 && !l.startsWith('//'));
+
+const SAMPLE = [
+    'title Tea Shop',
+    'anchor Business [0.95, 0.63]',
+    'component Cup of Tea [0.79, 0.61]',
+    'component Kettle [0.43, 0.35]',
+    'Business -> Cup of Tea',
+    'Cup of Tea -> Kettle',
+    'evolve Kettle 0.62',
+    'market Buyers [0.9, 0.5]',
+].join('\n');
+
+describe('OWM <-> Mermaid round trip', () => {
+    it('preserves every meaningful line', () => {
+        const mermaid = exportToMermaid(SAMPLE).mermaid;
+        const backToOwm = importFromMermaid(mermaid);
+        const original = normalise(SAMPLE);
+        const result = normalise(backToOwm);
+        for (const line of original) {
+            expect(result).toContain(line);
+        }
+    });
+
+    it('round-trips the OWM-only market keyword', () => {
+        const mermaid = exportToMermaid(SAMPLE).mermaid;
+        expect(mermaid).toContain('%% market Buyers [0.9, 0.5]');
+        expect(normalise(importFromMermaid(mermaid))).toContain('market Buyers [0.9, 0.5]');
+    });
+});

--- a/frontend/src/__tests__/repository/github/GitHubClient.test.ts
+++ b/frontend/src/__tests__/repository/github/GitHubClient.test.ts
@@ -1,0 +1,54 @@
+import {GitHubClient, GitHubApiError} from '../../../repository/github/GitHubClient';
+
+const SOURCE = {owner: 'a', repo: 'b', branch: 'main', path: 'm.md'};
+
+// base64 of "hello" is "aGVsbG8="
+const b64 = (s: string) => Buffer.from(s, 'utf8').toString('base64');
+
+describe('GitHubClient', () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    it('readFile decodes content and returns the sha', async () => {
+        jest.spyOn(global, 'fetch').mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({content: b64('hello'), encoding: 'base64', sha: 'sha1'}),
+        } as Response);
+
+        const client = new GitHubClient('ghp_token');
+        const file = await client.readFile(SOURCE);
+        expect(file).toEqual({content: 'hello', sha: 'sha1'});
+    });
+
+    it('readFile throws GitHubApiError with the status on failure', async () => {
+        jest.spyOn(global, 'fetch').mockResolvedValue({
+            ok: false,
+            status: 404,
+            json: async () => ({message: 'Not Found'}),
+        } as Response);
+
+        const client = new GitHubClient('ghp_token');
+        await expect(client.readFile(SOURCE)).rejects.toMatchObject({
+            name: 'GitHubApiError',
+            status: 404,
+        });
+    });
+
+    it('commitFile sends the sha and returns the new sha', async () => {
+        const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({content: {sha: 'sha2'}}),
+        } as Response);
+
+        const client = new GitHubClient('ghp_token');
+        const result = await client.commitFile(SOURCE, 'new content', 'msg', 'sha1');
+        expect(result).toEqual({sha: 'sha2'});
+
+        const [, init] = fetchMock.mock.calls[0];
+        const body = JSON.parse((init as RequestInit).body as string);
+        expect(body.sha).toBe('sha1');
+        expect(body.branch).toBe('main');
+        expect(body.message).toBe('msg');
+    });
+});

--- a/frontend/src/__tests__/repository/github/GitHubLoadStrategy.test.ts
+++ b/frontend/src/__tests__/repository/github/GitHubLoadStrategy.test.ts
@@ -32,4 +32,17 @@ describe('GitHubLoadStrategy', () => {
         const strategy = new GitHubLoadStrategy(jest.fn());
         await expect(strategy.load('acme/maps/main/tea.md')).rejects.toThrow(/token/i);
     });
+
+    it('rejects with GitHubLoadCancelled when no fence and user declines confirm', async () => {
+        const fileWithNoFence = '# Just markdown\nNo mermaid fence here.';
+        jest.spyOn(GitHubClient.prototype, 'readFile').mockResolvedValue({content: fileWithNoFence, sha: 'sha2'});
+        jest.spyOn(window, 'confirm').mockReturnValue(false);
+
+        const callback = jest.fn();
+        const strategy = new GitHubLoadStrategy(callback);
+        await expect(strategy.load('acme/maps/main/docs/tea.md')).rejects.toMatchObject({
+            name: 'GitHubLoadCancelled',
+        });
+        expect(callback).not.toHaveBeenCalled();
+    });
 });

--- a/frontend/src/__tests__/repository/github/GitHubLoadStrategy.test.ts
+++ b/frontend/src/__tests__/repository/github/GitHubLoadStrategy.test.ts
@@ -1,0 +1,35 @@
+import {GitHubLoadStrategy} from '../../../repository/GitHubLoadStrategy';
+import {GitHubClient} from '../../../repository/github/GitHubClient';
+import {setGitHubToken, clearGitHubToken} from '../../../repository/github/GitHubToken';
+import {getSession, clearSession} from '../../../repository/github/GitHubMapSession';
+
+const FILE = ['# Map', '```mermaid', 'wardley-beta', 'component Foo [0.5, 0.5]', '```'].join('\n');
+
+describe('GitHubLoadStrategy', () => {
+    beforeEach(() => setGitHubToken('ghp_token'));
+    afterEach(() => {
+        clearGitHubToken();
+        clearSession();
+        jest.restoreAllMocks();
+    });
+
+    it('loads a map, imports it to OWM DSL, and stores the session', async () => {
+        jest.spyOn(GitHubClient.prototype, 'readFile').mockResolvedValue({content: FILE, sha: 'sha1'});
+
+        const callback = jest.fn();
+        const strategy = new GitHubLoadStrategy(callback);
+        await strategy.load('acme/maps/main/docs/tea.md');
+
+        const [strategyName, data] = callback.mock.calls[0];
+        expect(strategyName).toBe('GitHub');
+        expect(data.mapText).toContain('component Foo [0.5, 0.5]');
+        expect(data.mapText).not.toContain('wardley-beta');
+        expect(getSession()?.sha).toBe('sha1');
+    });
+
+    it('throws when no token is stored', async () => {
+        clearGitHubToken();
+        const strategy = new GitHubLoadStrategy(jest.fn());
+        await expect(strategy.load('acme/maps/main/tea.md')).rejects.toThrow(/token/i);
+    });
+});

--- a/frontend/src/__tests__/repository/github/GitHubMapSession.test.ts
+++ b/frontend/src/__tests__/repository/github/GitHubMapSession.test.ts
@@ -1,0 +1,26 @@
+import {setSession, getSession, clearSession} from '../../../repository/github/GitHubMapSession';
+
+const SAMPLE = {
+    source: {owner: 'a', repo: 'b', branch: 'main', path: 'm.md'},
+    sha: 'abc123',
+    rawFileContent: '# file',
+};
+
+describe('GitHubMapSession', () => {
+    afterEach(() => clearSession());
+
+    it('returns null when nothing is set', () => {
+        expect(getSession()).toBeNull();
+    });
+
+    it('stores and retrieves a session', () => {
+        setSession(SAMPLE);
+        expect(getSession()).toEqual(SAMPLE);
+    });
+
+    it('clears a session', () => {
+        setSession(SAMPLE);
+        clearSession();
+        expect(getSession()).toBeNull();
+    });
+});

--- a/frontend/src/__tests__/repository/github/GitHubSaveStrategy.test.ts
+++ b/frontend/src/__tests__/repository/github/GitHubSaveStrategy.test.ts
@@ -1,0 +1,46 @@
+import {GitHubSaveStrategy} from '../../../repository/GitHubSaveStrategy';
+import {GitHubClient} from '../../../repository/github/GitHubClient';
+import {setSession, getSession, clearSession} from '../../../repository/github/GitHubMapSession';
+import {setGitHubToken, clearGitHubToken} from '../../../repository/github/GitHubToken';
+
+const FILE = ['# Map', '```mermaid', 'wardley-beta', 'component Foo [0.5, 0.5]', '```'].join('\n');
+
+const map = (mapText: string) => ({readOnly: false, mapText, imageData: '', mapIterations: []});
+
+describe('GitHubSaveStrategy', () => {
+    beforeEach(() => {
+        setGitHubToken('ghp_testtoken');
+        setSession({
+            source: {owner: 'a', repo: 'b', branch: 'main', path: 'm.md'},
+            sha: 'sha1',
+            rawFileContent: FILE,
+        });
+        jest.spyOn(window, 'prompt').mockReturnValue('Update map');
+    });
+    afterEach(() => {
+        clearGitHubToken();
+        clearSession();
+        jest.restoreAllMocks();
+    });
+
+    it('commits the regenerated fence and updates the session sha', async () => {
+        const commit = jest.spyOn(GitHubClient.prototype, 'commitFile').mockResolvedValue({sha: 'sha2'});
+
+        const callback = jest.fn();
+        await new GitHubSaveStrategy(callback).save(map('component Bar [0.1, 0.2]'), 'a/b/main/m.md');
+
+        const committedContent = commit.mock.calls[0][1];
+        expect(committedContent).toContain('component Bar [0.1, 0.2]');
+        expect(committedContent).toContain('# Map'); // prose preserved
+        expect(commit.mock.calls[0][3]).toBe('sha1'); // sha sent
+        expect(getSession()?.sha).toBe('sha2'); // sha updated
+        expect(callback).toHaveBeenCalled();
+    });
+
+    it('aborts when the user cancels the commit-message prompt', async () => {
+        jest.spyOn(window, 'prompt').mockReturnValue(null);
+        const commit = jest.spyOn(GitHubClient.prototype, 'commitFile');
+        await new GitHubSaveStrategy(jest.fn()).save(map('component Bar [0.1, 0.2]'), 'a/b/main/m.md');
+        expect(commit).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/__tests__/repository/github/GitHubToken.test.ts
+++ b/frontend/src/__tests__/repository/github/GitHubToken.test.ts
@@ -1,0 +1,20 @@
+import {getGitHubToken, setGitHubToken, clearGitHubToken} from '../../../repository/github/GitHubToken';
+
+describe('GitHubToken', () => {
+    afterEach(() => clearGitHubToken());
+
+    it('returns null when no token is stored', () => {
+        expect(getGitHubToken()).toBeNull();
+    });
+
+    it('stores and retrieves a token', () => {
+        setGitHubToken('ghp_example');
+        expect(getGitHubToken()).toBe('ghp_example');
+    });
+
+    it('clears a token', () => {
+        setGitHubToken('ghp_example');
+        clearGitHubToken();
+        expect(getGitHubToken()).toBeNull();
+    });
+});

--- a/frontend/src/__tests__/repository/github/GitHubUrl.test.ts
+++ b/frontend/src/__tests__/repository/github/GitHubUrl.test.ts
@@ -1,0 +1,21 @@
+import {parseGitHubUrl} from '../../../repository/github/GitHubUrl';
+
+describe('parseGitHubUrl', () => {
+    it('parses a blob URL', () => {
+        const r = parseGitHubUrl('https://github.com/acme/maps/blob/main/docs/tea.md');
+        expect(r).toEqual({owner: 'acme', repo: 'maps', branch: 'main', path: 'docs/tea.md'});
+    });
+
+    it('parses a path with nested folders', () => {
+        const r = parseGitHubUrl('https://github.com/a/b/blob/dev/x/y/z.md');
+        expect(r).toEqual({owner: 'a', repo: 'b', branch: 'dev', path: 'x/y/z.md'});
+    });
+
+    it('returns null for a non-blob GitHub URL', () => {
+        expect(parseGitHubUrl('https://github.com/acme/maps')).toBeNull();
+    });
+
+    it('returns null for a non-GitHub URL', () => {
+        expect(parseGitHubUrl('https://example.com/foo')).toBeNull();
+    });
+});

--- a/frontend/src/__tests__/repository/github/MermaidFence.test.ts
+++ b/frontend/src/__tests__/repository/github/MermaidFence.test.ts
@@ -1,0 +1,32 @@
+import {extractMermaidFence, replaceMermaidFence} from '../../../repository/github/MermaidFence';
+
+const MD = ['# My Map', 'Some prose.', '```mermaid', 'wardley-beta', 'component Foo [0.5, 0.5]', '```', 'More prose.'].join('\n');
+
+describe('extractMermaidFence', () => {
+    it('extracts the wardley-beta fence body', () => {
+        const r = extractMermaidFence(MD);
+        expect(r.hasFence).toBe(true);
+        expect(r.body).toBe('wardley-beta\ncomponent Foo [0.5, 0.5]');
+    });
+
+    it('treats a file with no fence as the whole body', () => {
+        const r = extractMermaidFence('wardley-beta\ncomponent Foo [0.5, 0.5]');
+        expect(r.hasFence).toBe(false);
+        expect(r.body).toBe('wardley-beta\ncomponent Foo [0.5, 0.5]');
+    });
+});
+
+describe('replaceMermaidFence', () => {
+    it('replaces the fence body and keeps surrounding prose', () => {
+        const out = replaceMermaidFence(MD, 'wardley-beta\ncomponent Bar [0.1, 0.2]');
+        expect(out).toContain('# My Map');
+        expect(out).toContain('More prose.');
+        expect(out).toContain('component Bar [0.1, 0.2]');
+        expect(out).not.toContain('component Foo');
+    });
+
+    it('returns the new body alone when there was no fence', () => {
+        const out = replaceMermaidFence('wardley-beta\ncomponent Foo [0.5, 0.5]', 'wardley-beta\nx');
+        expect(out).toBe('wardley-beta\nx');
+    });
+});

--- a/frontend/src/components/MapEnvironment.tsx
+++ b/frontend/src/components/MapEnvironment.tsx
@@ -436,6 +436,15 @@ const MapEnvironmentWithUndoRedo: FunctionComponent<MapEnvironmentWithUndoRedoPr
         },
     ];
 
+    const openFromGitHub = useCallback(
+        (id: string) => {
+            setMapPersistenceStrategy(Defaults.MapPersistenceStrategy.GitHub);
+            setCurrentId(id);
+            setShouldLoad(true);
+        },
+        [setMapPersistenceStrategy, setCurrentId, setShouldLoad],
+    );
+
     const shouldHideNav = useCallback(() => {
         setHideNav(!hideNav);
     }, [hideNav]);
@@ -730,6 +739,7 @@ const MapEnvironmentWithUndoRedo: FunctionComponent<MapEnvironmentWithUndoRedoPr
                 saveOutstanding={saveOutstanding}
                 mutateMapText={mutateMapText}
                 newMapClick={mapPersistence.newMap}
+                openFromGitHub={openFromGitHub}
                 saveMapClick={mapPersistence.saveMap}
                 downloadMapImage={downloadMap}
                 showLineNumbers={showLineNumbers}

--- a/frontend/src/components/github/OpenFromGitHubDialog.test.tsx
+++ b/frontend/src/components/github/OpenFromGitHubDialog.test.tsx
@@ -1,0 +1,35 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import OpenFromGitHubDialog from './OpenFromGitHubDialog';
+import {clearGitHubToken, getGitHubToken, setGitHubToken} from '../../repository/github/GitHubToken';
+
+describe('OpenFromGitHubDialog', () => {
+    afterEach(() => clearGitHubToken());
+
+    it('rejects an invalid URL without calling onOpen', () => {
+        const onOpen = jest.fn();
+        setGitHubToken('ghp_token');
+        render(<OpenFromGitHubDialog open onClose={jest.fn()} onOpen={onOpen} />);
+
+        fireEvent.change(screen.getByLabelText(/github file url/i), {target: {value: 'not a url'}});
+        fireEvent.click(screen.getByRole('button', {name: /^open$/i}));
+
+        expect(onOpen).not.toHaveBeenCalled();
+        expect(screen.getByText(/not a valid github/i)).toBeInTheDocument();
+    });
+
+    it('calls onOpen with the id and stores the PAT for a valid URL', () => {
+        const onOpen = jest.fn();
+        render(<OpenFromGitHubDialog open onClose={jest.fn()} onOpen={onOpen} />);
+
+        fireEvent.change(screen.getByLabelText(/personal access token/i), {
+            target: {value: 'ghp_new'},
+        });
+        fireEvent.change(screen.getByLabelText(/github file url/i), {
+            target: {value: 'https://github.com/acme/maps/blob/main/docs/tea.md'},
+        });
+        fireEvent.click(screen.getByRole('button', {name: /^open$/i}));
+
+        expect(onOpen).toHaveBeenCalledWith('acme/maps/main/docs/tea.md');
+        expect(getGitHubToken()).toBe('ghp_new');
+    });
+});

--- a/frontend/src/components/github/OpenFromGitHubDialog.tsx
+++ b/frontend/src/components/github/OpenFromGitHubDialog.tsx
@@ -1,0 +1,92 @@
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Link from '@mui/material/Link';
+import TextField from '@mui/material/TextField';
+import React, {FunctionComponent, useState} from 'react';
+import {parseGitHubUrl, sourceToId} from '../../repository/github/GitHubUrl';
+import {getGitHubToken, setGitHubToken} from '../../repository/github/GitHubToken';
+
+interface OpenFromGitHubDialogProps {
+    open: boolean;
+    onClose: () => void;
+    onOpen: (id: string) => void;
+}
+
+const OpenFromGitHubDialog: FunctionComponent<OpenFromGitHubDialogProps> = ({open, onClose, onOpen}) => {
+    const hasToken = getGitHubToken() !== null;
+    const [url, setUrl] = useState('');
+    const [token, setToken] = useState('');
+    const [error, setError] = useState('');
+
+    const handleOpen = () => {
+        const source = parseGitHubUrl(url);
+        if (!source) {
+            setError('That is not a valid GitHub file URL (expected .../blob/...).');
+            return;
+        }
+        if (!hasToken && token.trim() === '') {
+            setError('A personal access token is required.');
+            return;
+        }
+        if (token.trim() !== '') setGitHubToken(token);
+        setError('');
+        onOpen(sourceToId(source));
+        onClose();
+    };
+
+    return (
+        <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+            <DialogTitle>Open map from GitHub</DialogTitle>
+            <DialogContent>
+                <DialogContentText sx={{mb: 2}}>
+                    Paste a link to a Markdown file containing a Mermaid <code>wardley-beta</code> block.
+                </DialogContentText>
+                <TextField
+                    autoFocus
+                    fullWidth
+                    margin="dense"
+                    label="GitHub file URL"
+                    placeholder="https://github.com/owner/repo/blob/branch/path.md"
+                    value={url}
+                    onChange={e => setUrl(e.target.value)}
+                />
+                {!hasToken && (
+                    <TextField
+                        fullWidth
+                        margin="dense"
+                        type="password"
+                        label="Personal access token"
+                        helperText={
+                            <>
+                                Needs Contents: read &amp; write.{' '}
+                                <Link href="https://github.com/settings/personal-access-tokens" target="_blank" rel="noreferrer">
+                                    Create one
+                                </Link>
+                                .
+                            </>
+                        }
+                        value={token}
+                        onChange={e => setToken(e.target.value)}
+                    />
+                )}
+                {error !== '' && (
+                    <DialogContentText color="error" sx={{mt: 1}}>
+                        {error}
+                    </DialogContentText>
+                )}
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose}>Cancel</Button>
+                <Button onClick={handleOpen} variant="contained">
+                    Open
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default OpenFromGitHubDialog;

--- a/frontend/src/components/map/components/MapLayout.tsx
+++ b/frontend/src/components/map/components/MapLayout.tsx
@@ -30,6 +30,7 @@ interface MapLayoutProps {
     saveOutstanding: boolean;
     mutateMapText: (text: string) => void;
     newMapClick: (strategy: string) => void;
+    openFromGitHub: (id: string) => void;
     saveMapClick: () => Promise<void>;
     downloadMapImage: () => void;
     showLineNumbers: boolean;
@@ -75,6 +76,7 @@ export const MapLayout: React.FC<MapLayoutProps> = ({
     saveOutstanding,
     mutateMapText,
     newMapClick,
+    openFromGitHub,
     saveMapClick,
     downloadMapImage,
     showLineNumbers,
@@ -130,6 +132,7 @@ export const MapLayout: React.FC<MapLayoutProps> = ({
                     saveOutstanding={saveOutstanding}
                     mutateMapText={mutateMapText}
                     newMapClick={newMapClick}
+                    openFromGitHub={openFromGitHub}
                     saveMapClick={saveMapClick}
                     downloadMapImage={downloadMapImage}
                     showLineNumbers={showLineNumbers}

--- a/frontend/src/components/map/hooks/useMapPersistence.ts
+++ b/frontend/src/components/map/hooks/useMapPersistence.ts
@@ -5,6 +5,7 @@ import {useI18n} from '../../../hooks/useI18n';
 import {LoadMap} from '../../../repository/LoadMap';
 import {MapIteration, OwnApiWardleyMap} from '../../../repository/OwnApiWardleyMap';
 import {SaveMap} from '../../../repository/SaveMap';
+import {GitHubApiError} from '../../../repository/github/GitHubClient';
 
 interface UseMapPersistenceProps {
     currentId: string;
@@ -87,7 +88,31 @@ export const useMapPersistence = (props: UseMapPersistenceProps): UseMapPersiste
                 });
             };
 
-            await SaveMap(mapPersistenceStrategy, mapToPersist, hash, followOnActions);
+            try {
+                await SaveMap(mapPersistenceStrategy, mapToPersist, hash, followOnActions);
+            } catch (error: unknown) {
+                let message: string;
+                if (error instanceof GitHubApiError) {
+                    const status = error.status;
+                    if (status === 401 || status === 403) {
+                        message =
+                            'GitHub rejected the request — check your token has Contents read & write permission for this repository.';
+                    } else if (status === 404) {
+                        message = 'File or branch not found on GitHub.';
+                    } else if (status === 409) {
+                        message = 'This file changed on GitHub since you opened it. Reload before saving.';
+                    } else {
+                        message = `GitHub error (${status}): ${error.message}`;
+                    }
+                } else if (error instanceof Error) {
+                    message = error.message || 'Could not complete the GitHub operation.';
+                } else {
+                    message = 'Could not complete the GitHub operation.';
+                }
+                window.alert(message);
+                setActionInProgress(false);
+                setCurrentUrl(window.location.href);
+            }
         },
         [currentId, mapPersistenceStrategy, mapText, mapIterations, setActionInProgress, setCurrentId, setCurrentUrl, setSaveOutstanding],
     );
@@ -126,7 +151,35 @@ export const useMapPersistence = (props: UseMapPersistenceProps): UseMapPersiste
         setActionInProgress(true);
         setCurrentUrl('(loading...)');
         console.log('--- Set Load Strategy: ', mapPersistenceStrategy);
-        await LoadMap(mapPersistenceStrategy, followOnActions, currentId);
+        try {
+            await LoadMap(mapPersistenceStrategy, followOnActions, currentId);
+        } catch (error: unknown) {
+            if (error instanceof Error && error.name === 'GitHubLoadCancelled') {
+                // User deliberately cancelled — no alert needed.
+            } else {
+                let message: string;
+                if (error instanceof GitHubApiError) {
+                    const status = error.status;
+                    if (status === 401 || status === 403) {
+                        message =
+                            'GitHub rejected the request — check your token has Contents read & write permission for this repository.';
+                    } else if (status === 404) {
+                        message = 'File or branch not found on GitHub.';
+                    } else if (status === 409) {
+                        message = 'This file changed on GitHub since you opened it. Reload before saving.';
+                    } else {
+                        message = `GitHub error (${status}): ${error.message}`;
+                    }
+                } else if (error instanceof Error) {
+                    message = error.message || 'Could not complete the GitHub operation.';
+                } else {
+                    message = 'Could not complete the GitHub operation.';
+                }
+                window.alert(message);
+            }
+            setActionInProgress(false);
+            setCurrentUrl(window.location.href);
+        }
     }, [
         mapPersistenceStrategy,
         currentId,

--- a/frontend/src/components/page/NewHeader.tsx
+++ b/frontend/src/components/page/NewHeader.tsx
@@ -14,6 +14,7 @@ import {alpha, styled} from '@mui/material/styles';
 import React, {FunctionComponent, MouseEvent, useRef, useState} from 'react';
 import {ExampleMap, MapPersistenceStrategy} from '../../constants/defaults';
 import {useI18n} from '../../hooks/useI18n';
+import OpenFromGitHubDialog from '../github/OpenFromGitHubDialog';
 import CoreHeader from './CoreHeader';
 
 interface StyledMenuProps {
@@ -68,6 +69,7 @@ export interface NewHeaderProps {
     setShowWysiwygToolbar: React.Dispatch<React.SetStateAction<boolean>>;
     showMapIterations: boolean;
     setShowMapIterations: React.Dispatch<React.SetStateAction<boolean>>;
+    openFromGitHub: (id: string) => void;
 }
 
 export const NewHeader: FunctionComponent<NewHeaderProps> = ({
@@ -89,9 +91,11 @@ export const NewHeader: FunctionComponent<NewHeaderProps> = ({
     setShowWysiwygToolbar,
     showMapIterations,
     setShowMapIterations,
+    openFromGitHub,
 }) => {
     const [anchorMoreEl, setAnchorMoreEl] = useState<Element | null>();
     const [modalShow, setModalShow] = useState(false);
+    const [gitHubDialogShow, setGitHubDialogShow] = useState(false);
 
     // Get translation function
     const {t} = useI18n();
@@ -130,6 +134,10 @@ export const NewHeader: FunctionComponent<NewHeaderProps> = ({
             anchorEl={anchorMoreEl}
             open={openMore}
             onClose={handleMenuClose}>
+            <MenuItem disableRipple onClick={() => handleMoreClose(() => setGitHubDialogShow(true))}>
+                Open from GitHub…
+            </MenuItem>
+            <Divider />
             <MenuItem disableRipple onClick={() => handleMoreClose(() => setModalShow(true))}>
                 {t('header.getCloneUrl', 'Get Clone URL')}
             </MenuItem>
@@ -234,6 +242,8 @@ export const NewHeader: FunctionComponent<NewHeaderProps> = ({
                     <Button onClick={saveMapClick}>{t('map.saveMap', 'Save Map')}</Button>
                 </DialogActions>
             </Dialog>
+
+            <OpenFromGitHubDialog open={gitHubDialogShow} onClose={() => setGitHubDialogShow(false)} onOpen={openFromGitHub} />
         </CoreHeader>
     );
 };

--- a/frontend/src/constants/defaults.ts
+++ b/frontend/src/constants/defaults.ts
@@ -9,6 +9,7 @@ export const increasedLabelOffset = {x: 5, y: -20};
 
 export const MapPersistenceStrategy = {
     Legacy: 'Legacy',
+    GitHub: 'GitHub',
 };
 
 export interface Offsets {

--- a/frontend/src/conversion/mermaid/MermaidExporter.ts
+++ b/frontend/src/conversion/mermaid/MermaidExporter.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import {isOwmOnlyLine} from './owmOnlyKeywords';
 /**
  * Shared OWM → Mermaid wardley-beta converter + file walker.
  * Consumed by test-real-maps.mjs (syntax validation) and
@@ -203,14 +204,11 @@ export function exportToMermaid(owmContent: string, titleFallback?: string): {me
         }
         if (!trimmed) continue;
 
-        if (/^style\s+wardley\s*$/i.test(trimmed)) continue;
-        if (/^(build|buy|outsource)\s+/i.test(trimmed)) continue;
-        if (/^[xy]-axis\s+/i.test(trimmed)) continue;
-        // Skip OWM `market <name> [vis, evo]` directive only — don't accidentally
-        // swallow links whose source component is named "Market ..." (e.g.,
-        // `Market segmentation -> Last Mile`).
-        if (/^market\s+[^[\]]+\[\s*[\d.]+\s*,/i.test(trimmed)) continue;
-        if (/^(ecosystem|submap|url|pioneer|settler|townplanner)\s+/i.test(trimmed)) continue;
+        if (isOwmOnlyLine(trimmed)) {
+            mermaidLines.push(`%% ${trimmed}`);
+            keptAsComments.push(trimmed);
+            continue;
+        }
 
         if (/^title\s+/i.test(trimmed)) {
             mermaidLines.push(trimmed);

--- a/frontend/src/conversion/mermaid/MermaidExporter.ts
+++ b/frontend/src/conversion/mermaid/MermaidExporter.ts
@@ -1,0 +1,437 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Shared OWM → Mermaid wardley-beta converter + file walker.
+ * Consumed by test-real-maps.mjs (syntax validation) and
+ * test-fidelity.mjs (conversion-fidelity comparison).
+ */
+
+// Characters that require quoting in the Mermaid wardley-beta grammar
+// (Mermaid >= 11.15.0; PR #7642 widened NAME_WITH_SPACES to accept hyphens
+// inside words, so hyphens are no longer in this set).
+export const NEEDS_QUOTING = /[&/+?'.<>=:%#(){};!@$^~`\\|[\]]/;
+
+// Keywords that shadow grammar terminals and need quoting
+export const KEYWORDS = new Set([
+    'market',
+    'build',
+    'buy',
+    'outsource',
+    'inertia',
+    'pipeline',
+    'evolve',
+    'anchor',
+    'component',
+    'note',
+    'title',
+    'size',
+    'evolution',
+    'annotations',
+    'annotation',
+    'accelerator',
+    'deaccelerator',
+    'label',
+]);
+
+// wardley-beta requires integer label offsets. OWM sources occasionally carry
+// fractional offsets (legacy renderers allowed them); round to the nearest
+// integer so the Mermaid parser accepts them. Returns null if the label
+// string doesn't parse as two numbers.
+function normaliseLabel(labelStr: string | null) {
+    if (!labelStr) return null;
+    const m = labelStr.match(/\[\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*\]/);
+    if (!m) return null;
+    return `[${Math.round(parseFloat(m[1]))}, ${Math.round(parseFloat(m[2]))}]`;
+}
+
+// Matches the Mermaid wardley-beta NAME_WITH_SPACES terminal verbatim
+// (Mermaid >= 11.15.0; PR #7642 added the `-(?!>)` alternation so hyphens
+// are allowed inside words except before `>`, preserving `A->B` arrow
+// tokenisation):
+//   [A-Za-z](?:[A-Za-z0-9_()&]|-(?!>))*(?:[ \t]+[A-Za-z(](?:[A-Za-z0-9_()&]|-(?!>))*)*
+// A name is safe unquoted iff it matches this; anything else (dots, slashes,
+// digit-start, standalone ampersand between spaces, etc.) must be wrapped in
+// "..." — which the grammar accepts as STRING in every place a name appears.
+const SAFE_NAME = /^[A-Za-z](?:[A-Za-z0-9_()&]|-(?!>))*(?:[ \t]+[A-Za-z(](?:[A-Za-z0-9_()&]|-(?!>))*)*$/;
+
+// Keywords that shadow grammar terminals. These must be quoted when they
+// appear either (a) as the first *word* of a name (e.g. `build release
+// cycle`) OR (b) as a prefix of the first word followed by letters
+// (e.g. `labelling`, `marketplace`, `evolved`, `building`) — the Mermaid
+// lexer tokenises the keyword greedily in both cases.
+const RESERVED_PREFIXES = [
+    'market',
+    'build',
+    'buy',
+    'outsource',
+    'inertia',
+    'pipeline',
+    'evolve',
+    'anchor',
+    'component',
+    'note',
+    'title',
+    'size',
+    'evolution',
+    'annotation',
+    'annotations',
+    'accelerator',
+    'deaccelerator',
+    'label',
+];
+
+function startsWithReserved(name: string) {
+    const first = name.split(/\s+/, 1)[0].toLowerCase();
+    for (const kw of RESERVED_PREFIXES) {
+        if (first === kw) return true;
+        if (first.length > kw.length && first.startsWith(kw) && /[a-z]/.test(first[kw.length])) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export function quoteName(name: string) {
+    if (!name) return name;
+    if (name.startsWith('"') && name.endsWith('"')) return name;
+    if (SAFE_NAME.test(name) && !startsWithReserved(name)) {
+        return name;
+    }
+    return `"${name.replace(/"/g, "'")}"`;
+}
+
+export function exportToMermaid(owmContent: string, titleFallback?: string): {mermaid: string; keptAsComments: string[]} {
+    const lines = owmContent.split('\n');
+    const mermaidLines = ['wardley-beta'];
+    const keptAsComments: string[] = [];
+    let hasTitleLine = false;
+
+    // ── PASS 1: Collect metadata for pipeline child detection ──
+    const sourcing: Record<string, any> = {};
+    const compCoords: Record<string, any> = {};
+    const pipelineRanges: Record<string, any> = {};
+    // Pipelines whose range declaration is followed (possibly across a blank
+    // line) by an explicit `{` block. Their children inside `{}` are
+    // authoritative; PASS 1b should not also auto-inject implicit children.
+    const pipelinesWithExplicitBlock = new Set<string>();
+
+    for (let i = 0; i < lines.length; i++) {
+        const trimmed = lines[i].trim();
+        if (trimmed.startsWith('//')) continue;
+
+        const srcMatch = trimmed.match(/^(build|buy|outsource)\s+(.+)/i);
+        if (srcMatch) {
+            sourcing[srcMatch[2].trim().toLowerCase()] = srcMatch[1].toLowerCase();
+        }
+
+        const compMatch = trimmed.match(/^component\s+(.+?)\s*\[\s*([\d.]+)\s*,\s*([\d.]+)\s*\](.*)$/);
+        if (compMatch) {
+            const labelMatch = compMatch[4].match(/\blabel\s+(\[-?[\d.,\s-]+\])/);
+            compCoords[compMatch[1].trim()] = {
+                vis: parseFloat(compMatch[2]),
+                evo: parseFloat(compMatch[3]),
+                label: labelMatch ? labelMatch[1] : null,
+            };
+        }
+
+        const pipeMatch = trimmed.match(/^pipeline\s+(.+?)\s*\[\s*([\d.]+)\s*,\s*([\d.]+)\s*\]\s*(\{?)\s*$/);
+        if (pipeMatch) {
+            const name = pipeMatch[1].trim();
+            pipelineRanges[name] = {
+                min: parseFloat(pipeMatch[2]),
+                max: parseFloat(pipeMatch[3]),
+            };
+            // Explicit block on same line: `pipeline X [a,b] {`
+            if (pipeMatch[4] === '{') {
+                pipelinesWithExplicitBlock.add(name);
+            } else {
+                // Look ahead for a `{` on a following line (skipping blanks/comments)
+                for (let j = i + 1; j < lines.length; j++) {
+                    const t = lines[j].trim();
+                    if (!t || t.startsWith('//')) continue;
+                    if (t === '{' || t.startsWith('{')) pipelinesWithExplicitBlock.add(name);
+                    break;
+                }
+            }
+        }
+    }
+
+    // ── PASS 1b: Detect pipeline children ──
+    const pipelineChildren: Record<string, Array<{name: string; evo: number; label: string | null}>> = {};
+    const isPipelineChild = new Set<string>();
+
+    for (const [pipeName, range] of Object.entries(pipelineRanges)) {
+        // Pipelines with an explicit `{ ... }` block own their children directly;
+        // skip implicit vis/evo proximity detection for those.
+        if (pipelinesWithExplicitBlock.has(pipeName)) continue;
+
+        const parent = compCoords[pipeName];
+        if (!parent) continue;
+
+        const children = [];
+        for (const [cName, cCoord] of Object.entries(compCoords)) {
+            if (cName === pipeName) continue;
+            if (isPipelineChild.has(cName)) continue;
+            if (Math.abs(cCoord.vis - parent.vis) <= 0.05 && cCoord.evo >= range.min - 0.01 && cCoord.evo <= range.max + 0.01) {
+                children.push({name: cName, evo: cCoord.evo, label: cCoord.label});
+            }
+        }
+
+        if (children.length > 0) {
+            children.sort((a, b) => a.evo - b.evo);
+            pipelineChildren[pipeName] = children;
+            for (const c of children) isPipelineChild.add(c.name);
+        }
+    }
+
+    // ── PASS 2: Convert lines ──
+    let inPipelineBlock = false;
+    let pendingPipelineName = null;
+
+    for (let i = 0; i < lines.length; i++) {
+        let trimmed = lines[i].trim();
+
+        if (!trimmed) {
+            mermaidLines.push('');
+            continue;
+        }
+
+        if (trimmed.startsWith('//')) continue;
+
+        const commentMatch = trimmed.match(/^(.+?)\s+\/\/(?!\/)(.*)$/);
+        if (commentMatch && !commentMatch[1].includes('://')) {
+            trimmed = commentMatch[1].trim();
+        }
+        if (!trimmed) continue;
+
+        if (/^style\s+wardley\s*$/i.test(trimmed)) continue;
+        if (/^(build|buy|outsource)\s+/i.test(trimmed)) continue;
+        if (/^[xy]-axis\s+/i.test(trimmed)) continue;
+        // Skip OWM `market <name> [vis, evo]` directive only — don't accidentally
+        // swallow links whose source component is named "Market ..." (e.g.,
+        // `Market segmentation -> Last Mile`).
+        if (/^market\s+[^[\]]+\[\s*[\d.]+\s*,/i.test(trimmed)) continue;
+        if (/^(ecosystem|submap|url|pioneer|settler|townplanner)\s+/i.test(trimmed)) continue;
+
+        if (/^title\s+/i.test(trimmed)) {
+            mermaidLines.push(trimmed);
+            mermaidLines.push('size [1100, 800]');
+            hasTitleLine = true;
+            continue;
+        }
+
+        if (/^evolution\s+/i.test(trimmed)) {
+            mermaidLines.push(trimmed);
+            continue;
+        }
+
+        if (/^anchor\s+/i.test(trimmed)) {
+            // wardley-beta's `anchor` rule doesn't accept a `label` clause; drop any
+            // OWM label on anchors and emit the bare anchor. Components keep them.
+            const anchorMatch = trimmed.match(/^anchor\s+(.+?)\s*(\[[\d.,\s]+\])/);
+            if (anchorMatch) {
+                const qName = quoteName(anchorMatch[1].trim());
+                mermaidLines.push(`anchor ${qName} ${anchorMatch[2]}`);
+            }
+            continue;
+        }
+
+        // OWM `pipeline X [min, max]` with optional trailing `{`. If the pipeline
+        // has an explicit `{ ... }` block (same line or next), open a Mermaid
+        // pipeline block using the parent's name. Otherwise skip — children are
+        // injected via the implicit detection in PASS 1b.
+        const pipeRangeMatch = trimmed.match(/^pipeline\s+(.+?)\s*\[\s*[\d.]+\s*,\s*[\d.]+\s*\]\s*(\{?)\s*$/i);
+        if (pipeRangeMatch) {
+            const name = pipeRangeMatch[1].trim();
+            if (pipelinesWithExplicitBlock.has(name)) {
+                const pName = quoteName(name);
+                if (pipeRangeMatch[2] === '{') {
+                    mermaidLines.push(`pipeline ${pName} {`);
+                    inPipelineBlock = true;
+                } else {
+                    pendingPipelineName = pName;
+                }
+            }
+            continue;
+        }
+
+        if (/^pipeline\s+/i.test(trimmed) && !trimmed.match(/\[[\d]/)) {
+            const nameMatch = trimmed.match(/^pipeline\s+(.+?)(?:\s*\{)?\s*$/i);
+            if (nameMatch) {
+                const pName = quoteName(nameMatch[1].trim());
+                if (trimmed.includes('{')) {
+                    mermaidLines.push(`pipeline ${pName} {`);
+                    inPipelineBlock = true;
+                } else {
+                    pendingPipelineName = pName;
+                }
+            }
+            continue;
+        }
+
+        if (pendingPipelineName && trimmed === '{') {
+            mermaidLines.push(`pipeline ${pendingPipelineName} {`);
+            inPipelineBlock = true;
+            pendingPipelineName = null;
+            continue;
+        }
+
+        if ((inPipelineBlock || pendingPipelineName) && trimmed === '}') {
+            if (pendingPipelineName) {
+                pendingPipelineName = null;
+            } else {
+                mermaidLines.push('}');
+                inPipelineBlock = false;
+            }
+            continue;
+        }
+
+        if (/^component\s+/i.test(trimmed)) {
+            const compMatch = trimmed.match(/^component\s+(.+?)\s*(\[[\d.,\s]+\])(.*)$/);
+            if (!compMatch) continue;
+
+            const compName = compMatch[1].trim();
+            const coords = compMatch[2];
+            const rest = compMatch[3];
+            const hasInertia = /\binertia\s*$/i.test(trimmed);
+            const rawLabelMatch = rest.match(/\blabel\s+(\[[^\]]+\])/);
+            const label = normaliseLabel(rawLabelMatch && rawLabelMatch[1]);
+
+            if (isPipelineChild.has(compName)) continue;
+
+            const qName = quoteName(compName);
+
+            let line;
+            if (inPipelineBlock) {
+                const innerCoord = coords.replace(/[\[\]]/g, '').trim();
+                line = `  component ${qName.startsWith('"') ? qName : `"${compName}"`} [${innerCoord}]`;
+            } else {
+                line = `component ${qName} ${coords}`;
+            }
+
+            // wardley-beta requires `label` to precede decorators, so append it
+            // before the (build)/(buy)/(outsource)/(inertia) markers.
+            if (label) line += ` label ${label}`;
+
+            const decorators = [];
+            if (sourcing[compName.toLowerCase()]) {
+                decorators.push(`(${sourcing[compName.toLowerCase()]})`);
+            }
+            if (hasInertia) decorators.push('(inertia)');
+            if (decorators.length > 0) line += ' ' + decorators.join(' ');
+
+            mermaidLines.push(line);
+
+            if (pipelineChildren[compName] && !inPipelineBlock) {
+                mermaidLines.push(`pipeline ${qName} {`);
+                for (const child of pipelineChildren[compName]) {
+                    let childLine = `  component ${quoteName(child.name)} [${child.evo}]`;
+                    const childLabel = normaliseLabel(child.label);
+                    if (childLabel) childLine += ` label ${childLabel}`;
+                    mermaidLines.push(childLine);
+                }
+                mermaidLines.push('}');
+            }
+
+            continue;
+        }
+
+        if (/^evolve\s+/i.test(trimmed)) {
+            // Require the position to be a properly-formed number followed by
+            // whitespace or EOL — avoids misparsing names containing ".X" (e.g.
+            // `evolve Lamp / .Net 0.72` would previously capture "." as position).
+            const evolveMatch = trimmed.match(/^evolve\s+(.+?)\s+(\d+(?:\.\d+)?)(?=\s|$)/i);
+            if (evolveMatch) {
+                const eName = quoteName(evolveMatch[1].trim());
+                mermaidLines.push(`evolve ${eName} ${evolveMatch[2]}`);
+            }
+            continue;
+        }
+
+        if (/^note\s+/i.test(trimmed)) {
+            const noteMatch = trimmed.match(/^note\s+(.+)\s+(\[[\d.,\s]+\])\s*$/i);
+            if (noteMatch) {
+                let noteText = noteMatch[1].trim();
+                const noteCoord = noteMatch[2];
+                const labelIdx = noteText.lastIndexOf('] label ');
+                if (labelIdx > 0) {
+                    noteText = noteText.substring(0, labelIdx + 1);
+                }
+                noteText = noteText.replace(/^"/, '').replace(/"$/, '');
+                noteText = `"${noteText.replace(/"/g, "'")}"`;
+                mermaidLines.push(`note ${noteText} ${noteCoord}`);
+            }
+            continue;
+        }
+
+        if (/^annotations\s+\[/i.test(trimmed)) {
+            mermaidLines.push(trimmed);
+            continue;
+        }
+
+        if (/^annotation\s+\d/i.test(trimmed)) {
+            const annoMatch = trimmed.match(/^annotation\s+(\d+)\s*,?\s*(\[[\d.,\s]+\])\s*(.*)/i);
+            if (annoMatch) {
+                const num = annoMatch[1];
+                const coords = annoMatch[2];
+                let text = annoMatch[3].trim();
+                if (text && !text.startsWith('"')) {
+                    text = `"${text.replace(/"/g, "'")}"`;
+                }
+                if (text) {
+                    mermaidLines.push(`annotation ${num},${coords} ${text}`);
+                } else {
+                    mermaidLines.push(`annotation ${num},${coords}`);
+                }
+            }
+            continue;
+        }
+
+        if (trimmed.includes('->') && !/^(evolve|component|pipeline|anchor|note)\s/i.test(trimmed)) {
+            let linkLine = trimmed;
+
+            let annotation = '';
+            const semiIdx = linkLine.indexOf(';');
+            if (semiIdx > 0) {
+                annotation = linkLine.substring(semiIdx);
+                linkLine = linkLine.substring(0, semiIdx).trim();
+            }
+
+            const arrowIdx = linkLine.indexOf('->');
+            if (arrowIdx > 0) {
+                let left = linkLine.substring(0, arrowIdx).trim();
+                let right = linkLine.substring(arrowIdx + 2).trim();
+
+                left = quoteName(left);
+                right = quoteName(right);
+
+                linkLine = `${left} -> ${right}`;
+            }
+
+            if (annotation) {
+                linkLine += annotation;
+            }
+
+            mermaidLines.push(linkLine);
+            continue;
+        }
+    }
+
+    if (!hasTitleLine) {
+        const defaultTitle = (titleFallback || 'Wardley Map').replace(/[-_]/g, ' ');
+        mermaidLines.splice(1, 0, `title ${defaultTitle}`, 'size [1100, 800]');
+    }
+
+    const cleaned = [];
+    let lastEmpty = false;
+    for (const line of mermaidLines) {
+        if (line === '') {
+            if (!lastEmpty) cleaned.push(line);
+            lastEmpty = true;
+        } else {
+            cleaned.push(line);
+            lastEmpty = false;
+        }
+    }
+
+    return {mermaid: cleaned.join('\n'), keptAsComments};
+}

--- a/frontend/src/conversion/mermaid/MermaidImporter.ts
+++ b/frontend/src/conversion/mermaid/MermaidImporter.ts
@@ -1,0 +1,25 @@
+import {isOwmOnlyLine} from './owmOnlyKeywords';
+
+// Converts a Mermaid wardley-beta diagram body into OWM DSL. The body is
+// already valid OWM apart from the `wardley-beta` header and the
+// auto-injected `size` line; `%%` comments holding OWM-only keywords
+// (written by exportToMermaid) are un-commented.
+export const importFromMermaid = (mermaidText: string): string => {
+    const out: string[] = [];
+    for (const line of mermaidText.split('\n')) {
+        const trimmed = line.trim();
+
+        if (/^wardley-beta\s*$/i.test(trimmed)) continue;
+        if (/^size\s*\[/i.test(trimmed)) continue;
+
+        const commentMatch = trimmed.match(/^%%\s?(.*)$/);
+        if (commentMatch) {
+            const body = commentMatch[1];
+            if (isOwmOnlyLine(body.trim())) out.push(body);
+            continue;
+        }
+
+        out.push(line);
+    }
+    return out.join('\n');
+};

--- a/frontend/src/conversion/mermaid/owmOnlyKeywords.ts
+++ b/frontend/src/conversion/mermaid/owmOnlyKeywords.ts
@@ -1,0 +1,18 @@
+// OWM keywords that have no Mermaid wardley-beta equivalent. Lines matching
+// these are preserved as `%%` comments on export and restored on import.
+const OWM_ONLY_PATTERNS: RegExp[] = [
+    /^style\s+wardley\s*$/i,
+    /^(build|buy|outsource)\s+/i,
+    /^[xy]-axis\s+/i,
+    // `market <name> [vis, evo]` only — must not match links like
+    // `Market segmentation -> Last Mile`.
+    /^market\s+[^[\]]+\[\s*[\d.]+\s*,/i,
+    /^(ecosystem|submap|url)\s+/i,
+    /^(pioneers|settlers|townplanners|explorers|villagers)\s*\[/i,
+    /^(accelerator|deaccelerator)\s+/i,
+];
+
+export const isOwmOnlyLine = (line: string): boolean => {
+    const trimmed = line.trim();
+    return OWM_ONLY_PATTERNS.some(re => re.test(trimmed));
+};

--- a/frontend/src/conversion/mermaid/owmOnlyKeywords.ts
+++ b/frontend/src/conversion/mermaid/owmOnlyKeywords.ts
@@ -1,7 +1,7 @@
 // OWM keywords that have no Mermaid wardley-beta equivalent. Lines matching
 // these are preserved as `%%` comments on export and restored on import.
 const OWM_ONLY_PATTERNS: RegExp[] = [
-    /^style\s+wardley\s*$/i,
+    /^style\s+[\w-]+\s*$/i,
     /^(build|buy|outsource)\s+/i,
     /^[xy]-axis\s+/i,
     // `market <name> [vis, evo]` only — must not match links like

--- a/frontend/src/repository/GitHubLoadStrategy.ts
+++ b/frontend/src/repository/GitHubLoadStrategy.ts
@@ -1,0 +1,32 @@
+import {importFromMermaid} from '../conversion/mermaid/MermaidImporter';
+import * as Defaults from '../constants/defaults';
+import {GitHubClient} from './github/GitHubClient';
+import {extractMermaidFence} from './github/MermaidFence';
+import {setSession} from './github/GitHubMapSession';
+import {getGitHubToken} from './github/GitHubToken';
+import {idToSource} from './github/GitHubUrl';
+import {LoadStrategy} from './LoadStrategy';
+
+export class GitHubLoadStrategy extends LoadStrategy {
+    async load(id: string): Promise<void> {
+        const token = getGitHubToken();
+        if (!token) {
+            throw new Error('No GitHub token configured. Add a personal access token first.');
+        }
+
+        const source = idToSource(id);
+        const client = new GitHubClient(token);
+        const file = await client.readFile(source);
+
+        const {body} = extractMermaidFence(file.content);
+        const mapText = importFromMermaid(body);
+
+        setSession({source, sha: file.sha, rawFileContent: file.content});
+
+        this.callback(Defaults.MapPersistenceStrategy.GitHub, {
+            id,
+            mapText,
+            mapIterations: [],
+        });
+    }
+}

--- a/frontend/src/repository/GitHubLoadStrategy.ts
+++ b/frontend/src/repository/GitHubLoadStrategy.ts
@@ -18,7 +18,15 @@ export class GitHubLoadStrategy extends LoadStrategy {
         const client = new GitHubClient(token);
         const file = await client.readFile(source);
 
-        const {body} = extractMermaidFence(file.content);
+        const {body, hasFence} = extractMermaidFence(file.content);
+        if (!hasFence) {
+            const proceed = window.confirm('No Mermaid wardley-beta diagram was found in this file. Open the whole file as a map anyway?');
+            if (!proceed) {
+                const cancelled = new Error('GitHub load cancelled by user.');
+                cancelled.name = 'GitHubLoadCancelled';
+                throw cancelled;
+            }
+        }
         const mapText = importFromMermaid(body);
 
         setSession({source, sha: file.sha, rawFileContent: file.content});

--- a/frontend/src/repository/GitHubSaveStrategy.ts
+++ b/frontend/src/repository/GitHubSaveStrategy.ts
@@ -23,6 +23,7 @@ export class GitHubSaveStrategy implements SaveStrategy {
         const message = window.prompt('Commit message', 'Update Wardley map via OnlineWardleyMaps');
         if (message === null) return; // user cancelled
 
+        // keptAsComments (unsupported keywords preserved as %% comments) is intentionally not surfaced in the UI yet — see the design spec's out-of-scope list.
         const {mermaid} = exportToMermaid(map.mapText);
         const newFileContent = replaceMermaidFence(session.rawFileContent, mermaid);
 

--- a/frontend/src/repository/GitHubSaveStrategy.ts
+++ b/frontend/src/repository/GitHubSaveStrategy.ts
@@ -20,7 +20,7 @@ export class GitHubSaveStrategy implements SaveStrategy {
             throw new Error('No GitHub map is open. Open a map from GitHub before saving.');
         }
 
-        const message = window.prompt('Commit message', 'Update Wardley map via OnlineWardleyMaps');
+        const message = window.prompt('Commit message', 'Update Wardley map via create.wardleymaps.ai');
         if (message === null) return; // user cancelled
 
         // keptAsComments (unsupported keywords preserved as %% comments) is intentionally not surfaced in the UI yet — see the design spec's out-of-scope list.

--- a/frontend/src/repository/GitHubSaveStrategy.ts
+++ b/frontend/src/repository/GitHubSaveStrategy.ts
@@ -1,0 +1,35 @@
+import {exportToMermaid} from '../conversion/mermaid/MermaidExporter';
+import {GitHubClient} from './github/GitHubClient';
+import {getGitHubToken} from './github/GitHubToken';
+import {getSession, setSession} from './github/GitHubMapSession';
+import {replaceMermaidFence} from './github/MermaidFence';
+import {OwnApiWardleyMap} from './OwnApiWardleyMap';
+import {SaveStrategy} from './SaveStrategy';
+
+export class GitHubSaveStrategy implements SaveStrategy {
+    callback: (id: string, data: string) => void;
+
+    constructor(callback: (id: string, data: string) => void) {
+        this.callback = callback;
+    }
+
+    async save(map: OwnApiWardleyMap, hash: string): Promise<void> {
+        const token = getGitHubToken();
+        const session = getSession();
+        if (!token || !session) {
+            throw new Error('No GitHub map is open. Open a map from GitHub before saving.');
+        }
+
+        const message = window.prompt('Commit message', 'Update Wardley map via OnlineWardleyMaps');
+        if (message === null) return; // user cancelled
+
+        const {mermaid} = exportToMermaid(map.mapText);
+        const newFileContent = replaceMermaidFence(session.rawFileContent, mermaid);
+
+        const client = new GitHubClient(token);
+        const result = await client.commitFile(session.source, newFileContent, message, session.sha);
+
+        setSession({...session, sha: result.sha, rawFileContent: newFileContent});
+        this.callback(hash, JSON.stringify({id: hash}));
+    }
+}

--- a/frontend/src/repository/LoadMap.ts
+++ b/frontend/src/repository/LoadMap.ts
@@ -1,5 +1,6 @@
 import * as Defaults from '../constants/defaults';
 import {LegacyLoadStrategy} from './LegacyApiLoadStrategy';
+import {GitHubLoadStrategy} from './GitHubLoadStrategy';
 
 interface LoadStrategy {
     load(id: string): Promise<void>;
@@ -8,6 +9,7 @@ interface LoadStrategy {
 export const LoadMap = async (mapPersistenceStrategy: string, followOnActions: any, id: string): Promise<void> => {
     const loadStrategy: Record<string, () => LoadStrategy> = {
         [Defaults.MapPersistenceStrategy.Legacy]: () => new LegacyLoadStrategy(followOnActions),
+        [Defaults.MapPersistenceStrategy.GitHub]: () => new GitHubLoadStrategy(followOnActions),
     };
 
     await loadStrategy[mapPersistenceStrategy]().load(id);

--- a/frontend/src/repository/SaveMap.ts
+++ b/frontend/src/repository/SaveMap.ts
@@ -1,5 +1,6 @@
 import * as Defaults from '../constants/defaults';
 import LegacySaveStrategy from './LegacySaveStrategy';
+import {GitHubSaveStrategy} from './GitHubSaveStrategy';
 import {NullSaveStrategy} from './NullSaveStrategy';
 import {OwnApiWardleyMap} from './OwnApiWardleyMap';
 
@@ -13,6 +14,9 @@ export const SaveMap = async (
     switch (mapPersistenceStrategy) {
         case Defaults.MapPersistenceStrategy.Legacy:
             loadedSaveStrategy = new LegacySaveStrategy(callback);
+            break;
+        case Defaults.MapPersistenceStrategy.GitHub:
+            loadedSaveStrategy = new GitHubSaveStrategy(callback);
             break;
     }
     await loadedSaveStrategy.save(mapToPersist, hash);

--- a/frontend/src/repository/github/GitHubClient.ts
+++ b/frontend/src/repository/github/GitHubClient.ts
@@ -1,0 +1,77 @@
+import {GitHubSource} from './GitHubUrl';
+
+export interface GitHubFile {
+    content: string;
+    sha: string;
+}
+
+export class GitHubApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+        super(message);
+        this.name = 'GitHubApiError';
+        this.status = status;
+    }
+}
+
+const API = 'https://api.github.com';
+
+const decodeBase64 = (b64: string): string => {
+    const bytes = Uint8Array.from(atob(b64.replace(/\s/g, '')), c => c.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+};
+
+const encodeBase64 = (text: string): string => {
+    const bytes = new TextEncoder().encode(text);
+    let binary = '';
+    bytes.forEach(b => (binary += String.fromCharCode(b)));
+    return btoa(binary);
+};
+
+export class GitHubClient {
+    private token: string;
+
+    constructor(token: string) {
+        this.token = token;
+    }
+
+    private headers(): Record<string, string> {
+        return {
+            Authorization: `Bearer ${this.token}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+        };
+    }
+
+    private contentsUrl(s: GitHubSource): string {
+        return `${API}/repos/${s.owner}/${s.repo}/contents/${s.path}`;
+    }
+
+    async readFile(source: GitHubSource): Promise<GitHubFile> {
+        const url = `${this.contentsUrl(source)}?ref=${encodeURIComponent(source.branch)}`;
+        const response = await fetch(url, {headers: this.headers()});
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok) {
+            throw new GitHubApiError(response.status, data.message || 'GitHub read failed');
+        }
+        return {content: decodeBase64(data.content), sha: data.sha};
+    }
+
+    async commitFile(source: GitHubSource, content: string, message: string, sha: string): Promise<{sha: string}> {
+        const response = await fetch(this.contentsUrl(source), {
+            method: 'PUT',
+            headers: {...this.headers(), 'Content-Type': 'application/json'},
+            body: JSON.stringify({
+                message,
+                content: encodeBase64(content),
+                sha,
+                branch: source.branch,
+            }),
+        });
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok) {
+            throw new GitHubApiError(response.status, data.message || 'GitHub commit failed');
+        }
+        return {sha: data.content.sha};
+    }
+}

--- a/frontend/src/repository/github/GitHubClient.ts
+++ b/frontend/src/repository/github/GitHubClient.ts
@@ -44,7 +44,8 @@ export class GitHubClient {
     }
 
     private contentsUrl(s: GitHubSource): string {
-        return `${API}/repos/${s.owner}/${s.repo}/contents/${s.path}`;
+        const encodedPath = s.path.split('/').map(encodeURIComponent).join('/');
+        return `${API}/repos/${s.owner}/${s.repo}/contents/${encodedPath}`;
     }
 
     async readFile(source: GitHubSource): Promise<GitHubFile> {
@@ -71,6 +72,9 @@ export class GitHubClient {
         const data = await response.json().catch(() => ({}));
         if (!response.ok) {
             throw new GitHubApiError(response.status, data.message || 'GitHub commit failed');
+        }
+        if (!data.content?.sha) {
+            throw new GitHubApiError(response.status, 'GitHub commit returned an unexpected response.');
         }
         return {sha: data.content.sha};
     }

--- a/frontend/src/repository/github/GitHubMapSession.ts
+++ b/frontend/src/repository/github/GitHubMapSession.ts
@@ -1,0 +1,21 @@
+import {GitHubSource} from './GitHubUrl';
+
+export interface GitHubMapSession {
+    source: GitHubSource;
+    sha: string;
+    rawFileContent: string;
+}
+
+// Module-level singleton: the GitHub map is bound for the browser session
+// only. Reloading the page clears it (a known limitation — see the spec).
+let current: GitHubMapSession | null = null;
+
+export const setSession = (session: GitHubMapSession): void => {
+    current = session;
+};
+
+export const getSession = (): GitHubMapSession | null => current;
+
+export const clearSession = (): void => {
+    current = null;
+};

--- a/frontend/src/repository/github/GitHubToken.ts
+++ b/frontend/src/repository/github/GitHubToken.ts
@@ -1,0 +1,14 @@
+const KEY = 'owm.githubPat';
+
+// localStorage is unavailable during SSR; guard every access.
+const storage = (): Storage | null => (typeof window === 'undefined' ? null : window.localStorage);
+
+export const getGitHubToken = (): string | null => storage()?.getItem(KEY) ?? null;
+
+export const setGitHubToken = (token: string): void => {
+    storage()?.setItem(KEY, token.trim());
+};
+
+export const clearGitHubToken = (): void => {
+    storage()?.removeItem(KEY);
+};

--- a/frontend/src/repository/github/GitHubUrl.ts
+++ b/frontend/src/repository/github/GitHubUrl.ts
@@ -1,0 +1,22 @@
+export interface GitHubSource {
+    owner: string;
+    repo: string;
+    branch: string;
+    path: string;
+}
+
+// Parses https://github.com/{owner}/{repo}/blob/{branch}/{path...}
+export const parseGitHubUrl = (url: string): GitHubSource | null => {
+    const match = url.trim().match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/([^/]+)\/(.+)$/);
+    if (!match) return null;
+    const [, owner, repo, branch, path] = match;
+    return {owner, repo, branch, path};
+};
+
+// id form used by the persistence layer: owner/repo/branch/path...
+export const sourceToId = (s: GitHubSource): string => `${s.owner}/${s.repo}/${s.branch}/${s.path}`;
+
+export const idToSource = (id: string): GitHubSource => {
+    const [owner, repo, branch, ...rest] = id.split('/');
+    return {owner, repo, branch, path: rest.join('/')};
+};

--- a/frontend/src/repository/github/MermaidFence.ts
+++ b/frontend/src/repository/github/MermaidFence.ts
@@ -1,0 +1,30 @@
+export interface FenceResult {
+    body: string;
+    hasFence: boolean;
+}
+
+// Matches a ```mermaid ... ``` fenced block. Group 1 = opening fence line
+// (with any info string), group 2 = body, group 3 = closing fence.
+const FENCE_RE = /(```mermaid[^\n]*\n)([\s\S]*?)(\n```)/g;
+
+const findWardleyFence = (fileContent: string): RegExpExecArray | null => {
+    FENCE_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = FENCE_RE.exec(fileContent)) !== null) {
+        if (/^\s*wardley-beta\b/.test(match[2])) return match;
+    }
+    return null;
+};
+
+export const extractMermaidFence = (fileContent: string): FenceResult => {
+    const match = findWardleyFence(fileContent);
+    if (!match) return {body: fileContent, hasFence: false};
+    return {body: match[2].trim(), hasFence: true};
+};
+
+export const replaceMermaidFence = (fileContent: string, newBody: string): string => {
+    const match = findWardleyFence(fileContent);
+    if (!match) return newBody;
+    const replacement = `${match[1]}${newBody}${match[3]}`;
+    return fileContent.slice(0, match.index) + replacement + fileContent.slice(match.index + match[0].length);
+};

--- a/frontend/wmlandscape/src/index.js
+++ b/frontend/wmlandscape/src/index.js
@@ -80,6 +80,8 @@ import TitleExtractionStrategy from '../../src/conversion/TitleExtractionStrateg
 import {UnifiedConverter} from '../../src/conversion/UnifiedConverter';
 import UrlExtractionStrategy from '../../src/conversion/UrlExtractionStrategy';
 import XAxisLabelsExtractionStrategy from '../../src/conversion/XAxisLabelsExtractionStrategy';
+import {exportToMermaid} from '../../src/conversion/mermaid/MermaidExporter';
+import {importFromMermaid} from '../../src/conversion/mermaid/MermaidImporter';
 import {useLegacyMapState, useUnifiedMapState} from '../../src/hooks/useUnifiedMapState';
 import AllLinksStrategy from '../../src/linkStrategies/AllLinksStrategy';
 import AnchorLinksStrategy from '../../src/linkStrategies/AnchorLinksStrategy';
@@ -131,6 +133,7 @@ export {
     EvolvedToNoneEvolvingLinksStrategy,
     EvolveExtractionStrategy,
     EvolveToEvolvedLinksStrategy,
+    exportToMermaid,
     EvolvingComponentLink,
     EvolvingEndLinksStrategy,
     EvolvingToEvolvingLinksStrategy,
@@ -145,6 +148,7 @@ export {
     FeatureSwitchesProvider,
     FlowText,
     FluidLink,
+    importFromMermaid,
     Inertia,
     InertiaIcon,
     InertiaSymbol,


### PR DESCRIPTION
## Summary

Lets a user open a Wardley map stored as a Mermaid `wardley-beta` code fence in a GitHub repo, edit it in OnlineWardleyMaps, and commit it back — with GitHub rendering the diagram natively.

- **Bidirectional Mermaid converter** (`frontend/src/conversion/mermaid/`): `exportToMermaid` (a TypeScript port of the validated `tractorjuice/wardley-maps-mermaid` `convert.mjs`, modified to preserve OWM-only keywords as `%%` comments) and `importFromMermaid`. Re-exported from the `wmlandscape` package.
- **GitHub access** (`frontend/src/repository/github/`): URL parser, Mermaid-fence extract/replace, PAT `localStorage` store, in-memory map session, and a PAT-authenticated REST client.
- **Persistence**: `GitHubLoadStrategy` / `GitHubSaveStrategy` plugged into the existing `LoadMap` / `SaveMap` dispatchers via a new `MapPersistenceStrategy.GitHub`.
- **UI**: an "Open from GitHub…" menu item and `OpenFromGitHubDialog`; load/save errors surface to the user with status-mapped messages.

Design spec and implementation plan are in `docs/superpowers/`.

## Test Plan

- [x] `yarn test` — 145 suites, 1818 tests pass (2 pre-existing skips); includes converter unit tests, an OWM↔Mermaid round-trip suite, and GitHub client/strategy/dialog tests
- [x] `yarn build` — Next.js production build succeeds
- [x] `npx tsc --noEmit` — clean for all new/changed files
- [ ] Manual: open a GitHub Markdown file with a `wardley-beta` fence via the dialog, edit, save, confirm the commit lands with prose preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)